### PR TITLE
Fix docker sha inspect

### DIFF
--- a/src/madengine/tools/run_models.py
+++ b/src/madengine/tools/run_models.py
@@ -611,14 +611,14 @@ class RunModels:
                 run_details.base_docker = self.context.ctx["docker_build_arg"]["BASE_DOCKER"]
             else:
                 run_details.base_docker = self.console.sh(
-                    "grep 'ARG BASE_DOCKER=' "
+                    "grep '^ARG BASE_DOCKER=' "
                     + dockerfile
                     + " | sed -E 's/ARG BASE_DOCKER=//g'"
                 )
             print(f"BASE DOCKER is {run_details.base_docker}")
 
             # print base docker image digest
-            run_details.docker_sha = self.console.sh("docker inspect --format='{{index .RepoDigests 0}}' " + run_details.base_docker + " | cut -d '@' -f 2")
+            run_details.docker_sha = self.console.sh("docker manifest inspect " + run_details.base_docker + " | grep digest | head -n 1 | cut -d \\\" -f 4")
             print(f"BASE DOCKER SHA is {run_details.docker_sha}")
 
         else:


### PR DESCRIPTION
Turns out `docker build` with buildkit does not actually tag the pulled base image anymore (https://forums.docker.com/t/why-arent-base-layer-images-listed-in-docker-image-ls-a/139044/2), so the fix in #5 doesn't work. i.e. docker complains that the image e.g. `rocm/pytorch:latest` is not present.

Reverted to using `docker manifest inspect` which works with remote images+added some grep+cut commands to get around the jq dependency for parsing.

Also added a ^ in front of the grep for the BASE_DOCKER to fix issues like https://github.com/ROCm/DeepLearningModels/pull/2567.