### PR TITLE
Drop ipc option

### DIFF
--- a/src/madengine/tools/run_models.py
+++ b/src/madengine/tools/run_models.py
@@ -617,6 +617,8 @@ class RunModels:
                 )
             print(f"BASE DOCKER is {run_details.base_docker}")
 
+            self.console.sh("docker images")
+
             # print base docker image digest
             run_details.docker_sha = self.console.sh("docker inspect --format='{{index .RepoDigests 0}}' " + run_details.base_docker + " | cut -d '@' -f 2")
             print(f"BASE DOCKER SHA is {run_details.docker_sha}")

--- a/src/madengine/tools/run_models.py
+++ b/src/madengine/tools/run_models.py
@@ -634,9 +634,9 @@ class RunModels:
 
         if gpu_vendor.find("AMD") != -1:
             docker_options = "--network host -u root --group-add video \
-            --cap-add=SYS_PTRACE --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor=unconfined --ipc=host "
+            --cap-add=SYS_PTRACE --cap-add SYS_ADMIN --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor=unconfined "
         elif gpu_vendor.find("NVIDIA") != -1:
-            docker_options = "--cap-add=SYS_PTRACE --cap-add SYS_ADMIN --cap-add SYS_NICE --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor=unconfined  --network host -u root --ipc=host "
+            docker_options = "--cap-add=SYS_PTRACE --cap-add SYS_ADMIN --cap-add SYS_NICE --device /dev/fuse --security-opt seccomp=unconfined --security-opt apparmor=unconfined  --network host -u root "
         else:
             raise RuntimeError("Unable to determine gpu vendor.")
 

--- a/src/madengine/tools/run_models.py
+++ b/src/madengine/tools/run_models.py
@@ -617,9 +617,8 @@ class RunModels:
                 )
             print(f"BASE DOCKER is {run_details.base_docker}")
 
-            self.console.sh("docker images")
-
             # print base docker image digest
+            self.console.sh(f"docker pull {run_details.base_docker}")
             run_details.docker_sha = self.console.sh("docker inspect --format='{{index .RepoDigests 0}}' " + run_details.base_docker + " | cut -d '@' -f 2")
             print(f"BASE DOCKER SHA is {run_details.docker_sha}")
 


### PR DESCRIPTION
Currently `shm-size` option is not getting registered due to those `--ipc=host` are automatically setup on the docker run command. Dropping those to allow users to configure `shm-size`