### PR TITLE
Results size mismatch bug

### DIFF
--- a/src/madengine/tools/update_perf_csv.py
+++ b/src/madengine/tools/update_perf_csv.py
@@ -125,7 +125,7 @@ def handle_multiple_results(
         else:
             row["status"] = "FAILURE"
 
-        assert perf_csv_df.columns.size == len(row), f"Column count mismatch: CSV has {perf_csv_df.columns.size} columns but row has {len(row)} keys. CSV columns: {list(perf_csv_df.columns)}, Row keys: {list(row.keys())}"
+        assert perf_csv_df.columns.size == (len(row)-1), f"Column count mismatch: CSV has {perf_csv_df.columns.size} columns but row has {len(row)} keys. CSV columns: {list(perf_csv_df.columns)}, Row keys: {list(row.keys())}"
         final_multiple_results_df = pd.concat(
             [final_multiple_results_df, pd.DataFrame(row, index=[0])], ignore_index=True
         )


### PR DESCRIPTION
status column is added to row in this function where as the csv only has model perf metric causing mismatch this error wasnt seen before because code had issue of not using copy which allowed the assertion to pass recent fix adding copy now causes this to fail in ci  