### PR TITLE
Ignore rocm-smi's stderr in some commands.

### DIFF
--- a/src/madengine/core/console.py
+++ b/src/madengine/core/console.py
@@ -40,7 +40,8 @@ class Console:
             timeout: int=60, 
             secret: bool=False, 
             prefix: str="", 
-            env: typing.Optional[typing.Dict[str, str]]=None
+            env: typing.Optional[typing.Dict[str, str]]=None,
+            ignore_stderr: bool=False
         ) -> str:
         """Run shell command.
         
@@ -51,6 +52,7 @@ class Console:
             secret (bool): The flag to hide the command.
             prefix (str): The prefix of the output.
             env (typing_extensions.TypedDict): The environment variables.
+            ignore_stderr (bool): Don't include stderr in command's output.
         
         Returns:
             str: The output of the shell command.
@@ -67,7 +69,7 @@ class Console:
             command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=None if ignore_stderr else subprocess.STDOUT,
             shell=True,
             universal_newlines=True,
             bufsize=1,

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -52,3 +52,7 @@ class TestConsole:
     def test_sh_verbose(self):
         obj = console.Console(shellVerbose=False)
         assert obj.sh("echo MAD Engine") == "MAD Engine"
+
+    def test_sh_ignore_stderr(self):
+        obj = console.Console(shellVerbose=False)
+        assert obj.sh("echo fail 1>&2 | xargs echo success", ignore_stderr=True) == "success"


### PR DESCRIPTION
`rocm-smi` calls are usually either in pipelines or some scripts. `Console().sh()` returns both stdout and stderr of such commands, even if they're not expected. Inclusion of stderr in `Console().sh()`'s output can ruin some functions; hence I turn it off for some `rocm-smi` calls.