### PR TITLE
Fix DataFrame concatenation warning

### DIFF
--- a/src/madengine/tools/update_perf_csv.py
+++ b/src/madengine/tools/update_perf_csv.py
@@ -132,7 +132,11 @@ def handle_multiple_results(
 
     final_multiple_results_df = final_multiple_results_df[perf_csv_df.columns]
     perf_entry_df_to_csv(final_multiple_results_df)
-    perf_csv_df = pd.concat([perf_csv_df, final_multiple_results_df])
+    if perf_csv_df.empty:
+        perf_csv_df = final_multiple_results_df
+    else:
+        perf_csv_df = pd.concat([perf_csv_df, final_multiple_results_df])
+
     return perf_csv_df
 
 
@@ -154,9 +158,11 @@ def handle_single_result(
     """
     single_result_json = read_json(single_result)
     perf_entry_dict_to_csv(single_result_json)
-    perf_csv_df = pd.concat(
-        [perf_csv_df, pd.DataFrame(single_result_json, index=[0])], ignore_index=True
-    )
+    single_result_df = pd.DataFrame(single_result_json, index=[0])
+    if perf_csv_df.empty:
+        perf_csv_df = single_result_df[perf_csv_df.columns]
+    else:
+        perf_csv_df = pd.concat([perf_csv_df, single_result_df], ignore_index=True)
 
     return perf_csv_df
 
@@ -179,9 +185,11 @@ def handle_exception_result(
     """
     exception_result_json = read_json(exception_result)
     perf_entry_dict_to_csv(exception_result_json)
-    perf_csv_df = pd.concat(
-        [perf_csv_df, pd.DataFrame(exception_result_json, index=[0])], ignore_index=True
-    )
+    exception_result_df = pd.DataFrame(exception_result_json, index=[0])
+    if perf_csv_df.empty:
+        perf_csv_df = exception_result_df[perf_csv_df.columns]
+    else:
+        perf_csv_df = pd.concat([perf_csv_df, exception_result_df], ignore_index=True)
 
     return perf_csv_df
 


### PR DESCRIPTION
## Motivation

Fix DataFrame's FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.

## Technical Details

Skip concatenation if perf.csv is empty