### PR TITLE
Align CLI utils, dataprovider, container_runner with v2

### DIFF
--- a/src/madengine/cli/utils.py
+++ b/src/madengine/cli/utils.py
@@ -147,6 +147,16 @@ def display_results_table(summary: Dict, title: str, show_gpu_arch: bool = False
     if show_gpu_arch:
         table.add_column("GPU Architecture", style="blue")
 
+    def build_gpu_arch_display(item: Dict) -> str:
+        """Prefer gpu_architecture (DockerBuilder) then architecture (failures / legacy)."""
+        if not isinstance(item, dict):
+            return "N/A"
+        return (
+            item.get("gpu_architecture")
+            or item.get("architecture")
+            or "N/A"
+        )
+
     # Helper function to extract model name from build result
     def extract_model_name(item):
         if isinstance(item, dict):
@@ -242,7 +252,7 @@ def display_results_table(summary: Dict, title: str, show_gpu_arch: bool = False
                 status = "✅ Success"
                 row = [str(row_index), status, model_name]
                 if show_gpu_arch:
-                    row.append(item.get("architecture", "N/A"))
+                    row.append(build_gpu_arch_display(item))
                 table.add_row(*row)
                 row_index += 1
         else:
@@ -288,7 +298,7 @@ def display_results_table(summary: Dict, title: str, show_gpu_arch: bool = False
                 # BUILD results - simple format
                 row = [str(row_index), "❌ Failed", model_name]
                 if show_gpu_arch:
-                    row.append(item.get("architecture", "N/A"))
+                    row.append(build_gpu_arch_display(item))
                 table.add_row(*row)
                 row_index += 1
         else:

--- a/src/madengine/core/dataprovider.py
+++ b/src/madengine/core/dataprovider.py
@@ -649,6 +649,12 @@ class Data:
 
     def reorder_data_provider_config(self, dataname: str) -> None:
         """Reorder the data provider config to match the order of the ordered_data_provider_types"""
+        if dataname not in self.data_provider_config:
+            raise RuntimeError(
+                f'Unknown data name "{dataname}". Define it in data.json (or additional context '
+                f'"data") with at least one provider block (e.g. "local", "minio", "aws"). '
+                f"Known keys: {sorted(self.data_provider_config.keys())}"
+            )
         ordered_data_provider_types = [
             CustomDataProvider.provider_type,
             LocalDataProvider.provider_type,

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -238,7 +238,9 @@ class ContainerRunner:
             "deployment_type": os.environ.get("MAD_DEPLOYMENT_TYPE", "local"),  # local, slurm, etc.
             "launcher": launcher,  # Distributed launcher: torchrun, vllm, sglang, deepspeed, etc.
             "gpu_architecture": (
-                self.context.ctx["docker_env_vars"]["MAD_SYSTEM_GPU_ARCHITECTURE"]
+                (self.context.ctx.get("docker_env_vars") or {}).get(
+                    "MAD_SYSTEM_GPU_ARCHITECTURE", ""
+                )
                 if self.context
                 else ""
             ),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -17,6 +17,7 @@ import importlib
 import json
 import os
 import sys
+from io import StringIO
 import tempfile
 import unittest.mock
 from pathlib import Path
@@ -25,6 +26,7 @@ from unittest.mock import MagicMock, Mock, patch, mock_open
 # third-party modules
 import pytest
 import typer
+from rich.console import Console as RichConsole
 from typer.testing import CliRunner
 
 # project modules
@@ -155,6 +157,28 @@ class TestDisplayResultsTable:
             display_results_table(summary, "Build Results")
 
             mock_console.print.assert_called()
+
+    def test_display_results_table_build_shows_gpu_arch_from_docker_builder(self):
+        """Multi-arch builds record gpu_architecture; table must show it, not N/A."""
+        summary = {
+            "successful_builds": [
+                {"model": "dummy", "docker_image": "ci-dummy_dummy.ubuntu.amd_gfx90a", "gpu_architecture": "gfx90a"},
+                {"model": "dummy", "docker_image": "ci-dummy_dummy.ubuntu.amd_gfx942", "gpu_architecture": "gfx942"},
+            ],
+            "failed_builds": [],
+        }
+
+        with patch("madengine.cli.utils.console") as mock_console:
+            display_results_table(summary, "Build Results", show_gpu_arch=True)
+
+            mock_console.print.assert_called()
+            table_arg = mock_console.print.call_args[0][0]
+            buf = StringIO()
+            RichConsole(file=buf, width=120, force_terminal=True).print(table_arg)
+            rendered = buf.getvalue()
+            assert "gfx90a" in rendered
+            assert "gfx942" in rendered
+            assert "N/A" not in rendered
 
     def test_display_results_table_build_failures(self):
         """Test displaying build results table with failures."""


### PR DESCRIPTION
Align CLI utils, dataprovider, container_runner, test_cli with coketaste/v2-debug

fix(cli): build table GPU arch, safe perf GPU field, clearer data.json errors

Show GPU architecture in Build Results from DockerBuilder's gpu_architecture
field (multi-arch --target-archs builds), with fallback to architecture.
Avoid KeyError when manifest context has empty or missing docker_env_vars by
reading MAD_SYSTEM_GPU_ARCHITECTURE with nested get() in create_run_details_dict.
Raise a clear RuntimeError when a model's data name is missing from data.json,
including known keys, instead of a raw KeyError.
Add a unit test covering the build results table when gpu_architecture is set.
