### PR TITLE
feat(deployment): Primus on local/K8s/SLURM

### DIFF
--- a/docs/launchers.md
+++ b/docs/launchers.md
@@ -16,6 +16,7 @@ madengine provides unified support for multiple distributed frameworks, enabling
 | **DeepSpeed** | Training | ZeRO optimization training | ✅ | ✅ | ✅ |
 | **Megatron-LM** | Training | Large-scale transformer training | ✅ | ✅ | ✅ |
 | **TorchTitan** | Training | LLM pre-training (FSDP2+TP+PP) | ✅ | ✅ | ✅ |
+| **Primus** | Training | Megatron/TorchTitan/Jax via Primus config | ✅ | ✅ | ✅ |
 | **vLLM** | Inference | High-throughput LLM serving | ✅ | ✅ | ✅ |
 | **SGLang** | Inference | Fast LLM inference | ✅ | ✅ | ✅ |
 | **SGLang Disaggregated** | Inference | Large-scale disaggregated inference | ✅ | ✅ | ✅ (min 3) |
@@ -223,6 +224,49 @@ TORCHTITAN_CONTEXT_PARALLEL_SIZE=1
 **Examples**:
 - K8s: `examples/k8s-configs/minimal/torchtitan-single-node-minimal.json`
 - SLURM: `examples/slurm-configs/minimal/torchtitan-single-node-minimal.json`
+
+---
+
+### 5b. Primus
+
+**Purpose**: Unified pretrain entry for Megatron-LM, TorchTitan, and Jax/MaxText via Primus experiment YAML.
+
+**When to Use**:
+- Run Primus example configs (e.g. `examples/megatron/configs/MI300X/*.yaml`) via madengine
+- Single image plus config path; scheduling and tools/metrics from madengine
+
+**Configuration**:
+```json
+{
+  "distributed": {
+    "launcher": "primus",
+    "nnodes": 2,
+    "nproc_per_node": 8,
+    "primus": {
+      "config_path": "examples/megatron/configs/MI300X/deepseek_v2_lite-BF16-pretrain.yaml",
+      "cli_extra": "",
+      "backend": "megatron"
+    }
+  }
+}
+```
+
+Optional **`primus.backend`** (e.g. `MaxText`, `megatron`) emits `export BACKEND=...` before your model script when path-based detection is not enough. If omitted, madengine infers `BACKEND` from the **model name** when it follows `primus_pretrain/<launcher>_<arch>_...` (e.g. `primus_pretrain/torchtitan_MI300X_qwen3_4B-pretrain` → `torchtitan`), matching `scripts/primus_pretrain/get_models_json.py` in MAD-internal.
+
+**Features**:
+- Launcher sets `PRIMUS_CONFIG_PATH`, optional `PRIMUS_CLI_EXTRA`, and optional `BACKEND` from `primus.backend`; no `MAD_MULTI_NODE_RUNNER`
+- Model script (e.g. `run.sh`) sets `EXP` and calls Primus `run_pretrain.sh`
+- NNODES, NODE_RANK, MASTER_ADDR, etc. set by madengine job template
+- Use with MAD-Internal Primus submodule and `scripts/primus_pretrain/run.sh`
+
+**Container image**: Prefer `docker/primus.ubuntu.amd.Dockerfile` with `COPY scripts/Primus/ /workspace/Primus/` and `PRIMUS_ROOT=/workspace/Primus`. On **Kubernetes**, the Job’s emptyDir hides image files under `/workspace`; madengine bundles `scripts/Primus/examples/...` into the ConfigMap as `Primus/examples/...` so the init container recreates `/workspace/Primus`. `run.sh` resolves `PRIMUS_ROOT` in that order (see script comments).
+
+**Examples**:
+- SLURM: `examples/slurm-configs/minimal/primus-minimal.json`
+- K8s: `examples/k8s-configs/minimal/primus-minimal.json`
+- K8s (Primus vs upstream workload API, MaxText caveats, TorchTitan/Megatron/MaxText sample JSON): `examples/k8s-configs/README.md` section **Primus on Kubernetes**
+
+---
 
 **Model Configuration** (TOML):
 ```toml
@@ -519,16 +563,16 @@ madengine run --tags model --config custom-split-config.json
 
 ### Training Launchers
 
-| Feature | torchrun | DeepSpeed | Megatron-LM | TorchTitan |
-|---------|----------|-----------|-------------|------------|
-| **Data Parallel** | ✅ DDP | ✅ ZeRO | ✅ | ✅ FSDP2 |
-| **Tensor Parallel** | ❌ | ❌ | ✅ | ✅ |
-| **Pipeline Parallel** | ❌ | ✅ | ✅ | ✅ |
-| **Memory Efficiency** | Medium | High (ZeRO) | High | Very High |
-| **Ease of Use** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐ |
-| **Model Size** | Small-Medium | Medium-Large | Very Large | Very Large |
-| **K8s Support** | ✅ | ✅ | ✅ | ✅ |
-| **SLURM Support** | ✅ | ✅ | ✅ | ✅ |
+| Feature | torchrun | DeepSpeed | Megatron-LM | TorchTitan | Primus |
+|---------|----------|-----------|-------------|------------|--------|
+| **Data Parallel** | ✅ DDP | ✅ ZeRO | ✅ | ✅ FSDP2 | via config |
+| **Tensor Parallel** | ❌ | ❌ | ✅ | ✅ | via config |
+| **Pipeline Parallel** | ❌ | ✅ | ✅ | ✅ | via config |
+| **Memory Efficiency** | Medium | High (ZeRO) | High | Very High | config-driven |
+| **Ease of Use** | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ |
+| **Model Size** | Small-Medium | Medium-Large | Very Large | Very Large | config-driven |
+| **K8s Support** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **SLURM Support** | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Inference Launchers
 
@@ -646,6 +690,13 @@ TORCHTITAN_FSDP_ENABLED=1
 MAD_MULTI_NODE_RUNNER="torchrun ..."
 ```
 
+**Primus**:
+```bash
+PRIMUS_CONFIG_PATH="examples/megatron/configs/MI300X/..."
+PRIMUS_CLI_EXTRA=""   # optional
+# No MAD_MULTI_NODE_RUNNER (model script calls Primus run_pretrain.sh)
+```
+
 **vLLM**:
 ```bash
 VLLM_TENSOR_PARALLEL_SIZE=4
@@ -681,7 +732,7 @@ SGLANG_NODE_RANK=${SLURM_PROCID}
 ```bash
 Error: Unknown launcher type 'xyz'
 ```
-Solution: Use one of: `torchrun`, `deepspeed`, `megatron`, `torchtitan`, `vllm`, `sglang`, `sglang-disagg`
+Solution: Use one of: `torchrun`, `deepspeed`, `megatron`, `torchtitan`, `primus`, `vllm`, `sglang`, `sglang-disagg`
 
 **2. Multi-Node Communication Fails**
 ```bash

--- a/examples/k8s-configs/README.md
+++ b/examples/k8s-configs/README.md
@@ -185,9 +185,32 @@ To validate rendered YAML after a debug run, install [kubeconform](https://githu
 
 ### Multi-node DNS (PyTorch vs Ray)
 
-For **PyTorch-native** launchers (`torchrun`, `deepspeed`, `torchtitan`, `megatron`), multi-node Jobs use a **headless Service** whose name matches `pod.spec.subdomain`, per Kubernetes DNS rules, so pods get stable per-pod DNS names for rendezvous.
+For **PyTorch-native** launchers (`torchrun`, `deepspeed`, `torchtitan`, `megatron`, `primus`), multi-node Jobs use a **headless Service** whose name matches `pod.spec.subdomain`, per Kubernetes DNS rules, so pods get stable per-pod DNS names for rendezvous.
 
 For **Ray-based** multi-node (`vllm`, `sglang`), a headless Service may still be created for networking, but **per-pod DNS via `subdomain` is not applied** the same way as for PyTorch; production multi-node Ray on Kubernetes often uses **KubeRay** (see upstream vLLM / Ray docs). Treat Job-based multi-node Ray as a best-effort path.
+
+### Primus on Kubernetes
+
+Upstream Primus separates two ideas: a **universal** training driver (`examples/run_pretrain.sh`, used by all backends) and an optional **Kubernetes workload API client** (`examples/run_k8s_pretrain.sh`) that talks to a remote service to create workloads. Those are not the same integration as madengine’s native K8s path.
+
+| Approach | Role |
+|----------|------|
+| Primus `run_k8s_pretrain.sh` | HTTP client to an external **workload API** (replicas, image, `backend`, `exp`, node labels, etc.). Does **not** match madengine’s `kubectl`-style Job YAML flow. |
+| madengine `distributed.launcher: "primus"` | Renders a standard **Job** (and headless **Service** when `nnodes > 1`), injects cluster env (`MASTER_ADDR`, `NNODES`, `NODE_RANK` / `JOB_COMPLETION_INDEX`, `GPUS_PER_NODE`), `PRIMUS_CONFIG_PATH`, optional `PRIMUS_CLI_EXTRA`, and optional `BACKEND` from `distributed.primus.backend`, then runs your model script (e.g. `scripts/primus_pretrain/run.sh`). |
+
+**Backends** (one madengine launcher; Primus routes inside `run_pretrain.sh`):
+
+| Experiment path (typical) | Backend |
+|---------------------------|---------|
+| `examples/torchtitan/...` | TorchTitan (PyTorch / `torchrun`) |
+| `examples/megatron/...` | Megatron-LM |
+| `examples/maxtext/...` | MaxText (JAX; coordinator env from master) |
+
+Set `distributed.primus.config_path` to your YAML under the Primus repo layout. Use optional `distributed.primus.backend` (e.g. `MaxText`, `megatron`) to emit `export BACKEND=...` when you want to override inference. If `backend` is omitted, madengine sets `BACKEND` from the **model name** when it matches `primus_pretrain/<launcher>_<arch>_...` (e.g. `primus_pretrain/torchtitan_MI300X_qwen3_4B-pretrain` → `torchtitan`).
+
+**MaxText caveat:** For **multi-node** MaxText, Primus `run_pretrain.sh` may run **in-container `apt` installs** (InfiniBand-related packages). Many clusters disallow that unless the image is pre-baked or policy allows it. madengine logs a **warning** when MaxText is detected (`backend` or path) and `nnodes > 1`.
+
+Primus examples under [`basic/`](basic/): [`primus-single-node-multi-gpu.json`](basic/primus-single-node-multi-gpu.json) (one pod, multi-GPU) and [`primus-multi-node.json`](basic/primus-multi-node.json) (Indexed Job). The same files work for TorchTitan, Megatron, and MaxText: set `distributed.primus.config_path` to your experiment YAML, and rely on madengine’s `BACKEND` inference from the model name (`primus_pretrain/<launcher>_<arch>_...`) or set `distributed.primus.backend` only when you need an explicit override. Use `docker_env_vars.HF_TOKEN` as a placeholder or runtime secrets — do not commit real tokens.
 
 ### Full Configs (Reference Examples)
 
@@ -213,6 +236,8 @@ Complete configurations showing all available fields:
 | [`basic/torchtitan-multi-node-basic.json`](basic/torchtitan-multi-node-basic.json) | 8/node | 4 | TorchTitan | Llama 3.1 70B+ training |
 | [`basic/vllm-multi-node-basic.json`](basic/vllm-multi-node-basic.json) | 4/node | 2 | vLLM | High-throughput inference |
 | [`basic/sglang-multi-node-basic.json`](basic/sglang-multi-node-basic.json) | 4/node | 2 | SGLang | Distributed inference |
+| [`basic/primus-single-node-multi-gpu.json`](basic/primus-single-node-multi-gpu.json) | 8 | 1 | primus | Primus pretrain (single pod; edit `primus.config_path`) |
+| [`basic/primus-multi-node.json`](basic/primus-multi-node.json) | 8/node | 2+ | primus | Primus pretrain (multi-pod; edit `nnodes`, `primus.config_path`) |
 
 ---
 
@@ -551,12 +576,20 @@ Configuration for distributed workloads (training and inference):
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `launcher` | string | - | Launcher type: `torchrun`, `deepspeed`, `torchtitan`, `vllm`, `sglang` |
+| `launcher` | string | - | Launcher type: `torchrun`, `deepspeed`, `torchtitan`, `megatron`, `primus`, `vllm`, `sglang` |
 | `enabled` | boolean | `false` | Enable distributed execution (legacy, prefer `launcher`) |
 | `backend` | string | `"nccl"` | `"nccl"`, `"gloo"`, or `"mpi"` |
 | `nnodes` | integer | `1` | Number of nodes |
 | `nproc_per_node` | integer | gpu_count | Processes per node (= GPUs per node) |
 | `master_port` | integer | `29500` | Master communication port |
+
+When `launcher` is **`primus`**, set nested **`primus`** (under `distributed`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `primus.config_path` | string | Path to the Primus experiment YAML (e.g. under `examples/torchtitan/...`). |
+| `primus.cli_extra` | string | Optional extra arguments passed to Primus CLI. |
+| `primus.backend` | string | Optional. If set, madengine emits `export BACKEND=...` (e.g. `MaxText`, `megatron`) before your `run.sh`. |
 
 #### Environment Variables
 

--- a/src/madengine/deployment/common.py
+++ b/src/madengine/deployment/common.py
@@ -17,6 +17,7 @@ VALID_LAUNCHERS = [
     "torchtitan",
     "deepspeed",
     "megatron-lm",
+    "primus",
     "vllm",
     "sglang",
     "sglang-disagg"

--- a/src/madengine/deployment/k8s_names.py
+++ b/src/madengine/deployment/k8s_names.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Kubernetes-safe names for metadata.name, label values, and container names.
+
+Model names from data.json may contain ``/``, spaces, or uppercase letters that
+are invalid for ``metadata.name`` (RFC 1123 subdomain) or for label values.
+Container names must be a single DNS label (no dots), stricter than Job names.
+
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Final
+
+# Kubernetes DNS subdomain total length (metadata.name)
+_MAX_OBJECT_NAME_LEN: Final[int] = 253
+# Label value max length
+_MAX_LABEL_VALUE_LEN: Final[int] = 63
+# Container / initContainer names: DNS label only (no dots); see Pod validation.
+_MAX_DNS_LABEL_LEN: Final[int] = 63
+
+
+def _trim_edges_alnum(s: str) -> str:
+    """Ensure string starts and ends with [a-z0-9] (required for RFC1123 names)."""
+    s = s.strip("-.")
+    if not s:
+        return "x"
+    # Strip leading non-alphanumeric
+    while s and not s[0].isalnum():
+        s = s[1:]
+    while s and not s[-1].isalnum():
+        s = s[:-1]
+    return s or "x"
+
+
+def sanitize_k8s_object_name(prefix: str, raw_model_name: str, max_total_len: int = _MAX_OBJECT_NAME_LEN) -> str:
+    """
+    Build a valid ``metadata.name`` substring from a model name.
+
+    Args:
+        prefix: Leading segment (e.g. ``madengine``). May contain only chars valid in the final name.
+        raw_model_name: Original model name (may include ``/``, ``_``, spaces).
+        max_total_len: Maximum total length (default 253).
+
+    Returns:
+        A lowercase name safe for Kubernetes ``metadata.name`` (Job, PVC, Service, etc.).
+    """
+    raw = (raw_model_name or "").strip()
+    pfx = (prefix or "").strip().lower()
+    pfx = re.sub(r"[^a-z0-9.-]+", "-", pfx)
+    pfx = re.sub(r"-+", "-", pfx).strip("-")
+    if not pfx:
+        pfx = "madengine"
+
+    body = raw.lower()
+    body = re.sub(r"[^a-z0-9.-]+", "-", body)
+    body = re.sub(r"-+", "-", body).strip("-")
+    if not body:
+        body = "model"
+
+    combined = f"{pfx}-{body}"
+    combined = _trim_edges_alnum(combined)
+    # Dots are allowed in RFC1123 but avoid double semantics; keep as-is if present
+    if len(combined) <= max_total_len:
+        return combined
+
+    # Too long: stable short hash + truncated body
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+    # room: prefix + "-" + digest + "-" + rest
+    anchor = f"{pfx}-{digest}"
+    room = max_total_len - len(anchor) - 1
+    if room < 8:
+        # Extreme: prefix alone too long — fall back to hash-only tail
+        return _trim_edges_alnum(f"{digest}-{hashlib.sha256(raw.encode()).hexdigest()[:20]}")[:max_total_len]
+
+    tail = body[:room] if room > 0 else ""
+    tail = _trim_edges_alnum(tail) if tail else "m"
+    out = f"{anchor}-{tail}"
+    if len(out) > max_total_len:
+        out = out[:max_total_len]
+    return _trim_edges_alnum(out)
+
+
+def sanitize_k8s_container_name(name_hint: str, max_len: int = _MAX_DNS_LABEL_LEN) -> str:
+    """
+    Sanitize for ``spec.containers[].name`` / initContainer names.
+
+    Kubernetes rejects dots and other subdomain punctuation here: names must be a
+    single DNS **label** (``[a-z0-9]([-a-z0-9]*[a-z0-9])?``), max 63 characters.
+    Job/PVC ``metadata.name`` may still contain dots; do not reuse that string
+    verbatim as a container name.
+    """
+    s = (name_hint or "").strip().lower()
+    s = re.sub(r"[^a-z0-9-]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    if not s:
+        s = "madengine-main"
+    s = _trim_edges_alnum(s)
+    if len(s) > max_len:
+        digest = hashlib.sha256((name_hint or "").encode("utf-8")).hexdigest()[:8]
+        room = max_len - len(digest) - 1
+        if room < 4:
+            return digest[:max_len]
+        head = s[:room]
+        head = _trim_edges_alnum(head)
+        out = f"{digest}-{head}"
+        if len(out) > max_len:
+            out = out[:max_len]
+        return _trim_edges_alnum(out) or "m"
+    return s
+
+
+def sanitize_k8s_label_value(raw: str, max_len: int = _MAX_LABEL_VALUE_LEN) -> str:
+    """
+    Sanitize a string for use as a Kubernetes **label value** (max 63 chars).
+
+    Label values must be empty or begin/end with alphanumeric, with ``-``, ``_``, ``.`` inside.
+    """
+    s = (raw or "").strip().lower()
+    s = re.sub(r"[^a-z0-9._-]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-_.")
+    if not s:
+        return "model"
+    s = _trim_edges_alnum(s)
+    if len(s) <= max_len:
+        return s
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    # digest + '-' + remainder
+    remainder = max_len - len(digest) - 1
+    if remainder < 4:
+        return digest[:max_len]
+    tail = s[:remainder]
+    tail = _trim_edges_alnum(tail)
+    out = f"{digest}-{tail}"
+    if len(out) > max_len:
+        out = out[:max_len]
+    return _trim_edges_alnum(out)

--- a/src/madengine/deployment/kubernetes.py
+++ b/src/madengine/deployment/kubernetes.py
@@ -71,7 +71,17 @@ except ImportError:
     REPORTING_AVAILABLE = False
 
 
+from .k8s_names import (
+    sanitize_k8s_container_name,
+    sanitize_k8s_label_value,
+    sanitize_k8s_object_name,
+)
 from .kubernetes_launcher_mixin import KubernetesLauncherMixin
+from .primus_backend import (
+    infer_primus_backend_from_model_name,
+    infer_primus_examples_overlay_subdirs,
+    merged_primus_config,
+)
 
 
 def match_pvc_subdir_to_k8s_pod(
@@ -195,6 +205,7 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
 
         # Generated resources
         self.job_name = None
+        self.main_container_name = None
         self.configmap_name = None
         self.configmap_yaml = None
         self.job_yaml = None
@@ -272,9 +283,19 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
             model_info = self.manifest["built_models"][model_key]
             image_info = self.manifest["built_images"][model_key]
 
-            # Generate resource names (K8s compatible: lowercase, hyphens)
-            model_name = model_info["name"].lower().replace("_", "-")
-            self.job_name = f"madengine-{model_name}"
+            # Generate resource names (K8s compatible: no '/', spaces, etc.)
+            raw_model_name = model_info["name"]
+            self.job_name = sanitize_k8s_object_name("madengine", raw_model_name)
+            # Pod container names must be DNS labels (no dots); Job/PVC names may include dots.
+            self.main_container_name = sanitize_k8s_container_name(self.job_name)
+            if any(ch in raw_model_name for ch in "/\\ "):
+                self.console.print(
+                    f"[dim]K8s resource name (sanitized from model name): {self.job_name}[/dim]"
+                )
+            if self.main_container_name != self.job_name:
+                self.console.print(
+                    f"[dim]Pod container name (DNS label, no dots): {self.main_container_name}[/dim]"
+                )
             self.configmap_name = f"{self.job_name}-config"
 
             # Prepare template context
@@ -557,6 +578,98 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
                                                         script_contents[util_rel_path] = uf.read()
                                                     self.console.print(f"[dim]Loaded utility module (from dependency): {util_rel_path}[/dim]")
 
+    def _bundle_primus_k8s_examples_overlay(
+        self, model_scripts_contents: Dict[str, str], model_name: str = ""
+    ) -> None:
+        """
+        Add Primus experiment files from ``scripts/Primus`` into ``model_scripts_contents``
+        using ConfigMap keys under ``Primus/...`` (not ``scripts/Primus/...``).
+
+        The init container writes paths like ``/workspace/Primus/examples/...``, matching
+        ``PRIMUS_ROOT=/workspace/Primus`` in the Primus Dockerfile. The Job volume hides
+        image layers under ``/workspace``, so this bundle is what makes K8s runs work.
+
+        Always includes when present:
+
+        - ``requirements.txt`` (repo root; ``pip install -r`` from ``run_pretrain.sh``)
+        - ``examples/scripts/`` (``prepare_experiment.py``, NCCL helper shells, etc.)
+        - ``examples/run_pretrain.sh``
+        - The backend subtree from ``distributed.primus.config_path`` (torchtitan,
+          megatron, MaxText, …).
+        """
+        manifest = getattr(self, "manifest", None)
+        primus_cfg = merged_primus_config(
+            manifest if isinstance(manifest, dict) else None,
+            self.config.additional_context,
+        )
+        config_path = primus_cfg.get("config_path") or ""
+        backend_hint = (primus_cfg.get("backend") or "").strip()
+        subdirs = infer_primus_examples_overlay_subdirs(
+            config_path,
+            backend_hint=backend_hint,
+            model_name=model_name or "",
+        )
+        cwd = Path.cwd()
+        primus_repo = cwd / "scripts" / "Primus"
+        if not primus_repo.is_dir():
+            self.console.print(
+                f"[yellow]Primus K8s: {primus_repo} not found — skipping Primus ConfigMap bundle.[/yellow]"
+            )
+            return
+
+        def _add_primus_file(host_file: Path) -> bool:
+            try:
+                content = host_file.read_text(encoding="utf-8", errors="strict")
+            except (UnicodeDecodeError, OSError):
+                self.console.print(
+                    f"[dim]Skipping non-text Primus file for K8s bundle: {host_file}[/dim]"
+                )
+                return False
+            rel_under_repo = host_file.relative_to(primus_repo)
+            key = str(Path("Primus") / rel_under_repo)
+            model_scripts_contents[key] = content
+            return True
+
+        req = primus_repo / "requirements.txt"
+        if req.is_file():
+            if _add_primus_file(req):
+                self.console.print("[dim]Primus K8s: bundled Primus/requirements.txt[/dim]")
+
+        ex_scripts = primus_repo / "examples" / "scripts"
+        if ex_scripts.is_dir():
+            n_scripts = 0
+            for f in ex_scripts.rglob("*"):
+                if not f.is_file():
+                    continue
+                if _add_primus_file(f):
+                    n_scripts += 1
+            self.console.print(
+                f"[dim]Primus K8s: bundled Primus/examples/scripts for ConfigMap ({n_scripts} files)[/dim]"
+            )
+
+        run_pre = primus_repo / "examples" / "run_pretrain.sh"
+        if run_pre.is_file():
+            if _add_primus_file(run_pre):
+                self.console.print("[dim]Primus K8s: bundled Primus/examples/run_pretrain.sh[/dim]")
+
+        for sub in subdirs:
+            base = primus_repo / "examples" / sub
+            if not base.is_dir():
+                self.console.print(
+                    f"[yellow]Primus K8s: scripts/Primus/examples/{sub} not found under {cwd} — "
+                    "skipping that subtree.[/yellow]"
+                )
+                continue
+            n = 0
+            for f in base.rglob("*"):
+                if not f.is_file():
+                    continue
+                if _add_primus_file(f):
+                    n += 1
+            self.console.print(
+                f"[dim]Primus K8s: bundled Primus/examples/{sub} for ConfigMap ({n} files)[/dim]"
+            )
+
     def _prepare_template_context(
         self, model_info: Dict, image_info: Dict
     ) -> Dict[str, Any]:
@@ -765,6 +878,15 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
             
             self.console.print(f"[cyan]Configuring Megatron-LM: {nnodes} nodes × {nproc_per_node} GPUs/node[/cyan]")
 
+        elif launcher_type == "primus":
+            if not isinstance(nnodes, int) or nnodes < 1:
+                raise ValueError(f"Invalid nnodes: {nnodes}. Must be positive integer >= 1")
+            if not isinstance(nproc_per_node, int) or nproc_per_node < 1:
+                raise ValueError(f"Invalid nproc_per_node: {nproc_per_node}. Must be positive integer >= 1")
+            
+            self.console.print(f"[cyan]Configuring Primus: {nnodes} nodes × {nproc_per_node} GPUs/node[/cyan]")
+            self._bundle_primus_k8s_examples_overlay(model_scripts_contents, model_name)
+
         # Determine if we need multi-node setup
         create_headless_service = False
         launcher_command = None
@@ -882,6 +1004,38 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
                 model_script=model_info.get("scripts", "run.sh")
             )
 
+        elif launcher_type == "primus":
+            if nnodes > 1:
+                create_headless_service = True
+                self.console.print(f"[dim]Multi-node Primus: Creating headless service for pod discovery[/dim]")
+            
+            # Generate Primus launcher command (env-only: PRIMUS_CONFIG_PATH, PRIMUS_CLI_EXTRA)
+            launcher_command = self._generate_primus_command(
+                nnodes=nnodes,
+                nproc_per_node=nproc_per_node,
+                master_port=master_port,
+                model_script=model_info.get("scripts", "run.sh"),
+                model_args=model_info.get("args", "") or "",
+                model_name=model_info.get("name", "") or "",
+            )
+            primus_cfg = merged_primus_config(self.manifest, self.config.additional_context)
+            backend_hint = (primus_cfg.get("backend") or "").strip().lower()
+            inferred_backend = infer_primus_backend_from_model_name(
+                model_info.get("name", "") or ""
+            )
+            config_path_lower = (primus_cfg.get("config_path") or "").lower()
+            looks_maxtext = (
+                backend_hint == "maxtext"
+                or inferred_backend == "MaxText"
+                or "maxtext" in config_path_lower
+            )
+            if looks_maxtext and nnodes > 1:
+                self.console.print(
+                    "[yellow]Warning: Primus MaxText multi-node may run in-container apt installs "
+                    "(InfiniBand-related packages) inside run_pretrain.sh. Ensure your image or "
+                    "cluster policy allows this, or use a pre-baked image.[/yellow]"
+                )
+
         # Prepare pre/post scripts (similar to local execution)
         pre_scripts = []
         post_scripts = []
@@ -944,7 +1098,7 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
             privileged_profiling = bool(ap_prof)
 
         _pytorch_native = frozenset(
-            {"torchrun", "deepspeed", "torchtitan", "megatron"}
+            {"torchrun", "deepspeed", "torchtitan", "megatron", "primus"}
         )
         subdomain_val = (
             self.job_name
@@ -956,8 +1110,13 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
         context = {
             # Job metadata
             "job_name": self.job_name,
+            "main_container_name": getattr(
+                self, "main_container_name", None
+            )
+            or sanitize_k8s_container_name(self.job_name),
             "namespace": self.namespace,
             "model_name": model_name,
+            "model_label": sanitize_k8s_label_value(model_name),
             # ConfigMap
             "configmap_name": self.configmap_name,
             "manifest_content": manifest_content,
@@ -1201,7 +1360,7 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
             enriched_tools.append(enriched_tool)
         
         return enriched_tools
-    
+
     def _load_k8s_tools(self) -> Dict:
         """
         Load K8s-specific tools configuration.

--- a/src/madengine/deployment/kubernetes_launcher_mixin.py
+++ b/src/madengine/deployment/kubernetes_launcher_mixin.py
@@ -5,6 +5,8 @@
 
 from pathlib import Path
 
+from .primus_backend import infer_primus_backend_from_model_name, merged_primus_config
+
 
 class KubernetesLauncherMixin:
     def _generate_torchrun_command(
@@ -859,4 +861,98 @@ torchrun \\
     --master_addr=${{MASTER_ADDR}} \\
     --master_port={master_port} \\
     {model_script}"""
-    
+
+    def _generate_primus_command(
+        self,
+        nnodes: int,
+        nproc_per_node: int,
+        master_port: int,
+        model_script: str,
+        model_args: str = "",
+        model_name: str = "",
+    ) -> str:
+        """
+        Generate Primus launcher command for K8s Indexed Jobs.
+
+        Primus (TorchTitan, Megatron, MaxText, etc.) runs via ``run.sh`` →
+        ``examples/run_pretrain.sh``, which expects ``NNODES``, ``NODE_RANK``,
+        ``GPUS_PER_NODE``, ``MASTER_ADDR``, and ``MASTER_PORT`` (see Primus
+        ``run_pretrain.sh``). For multi-node jobs, ``NODE_RANK`` is
+        ``JOB_COMPLETION_INDEX`` (Indexed Job); the job template must export
+        ``JOB_COMPLETION_INDEX`` for Primus the same way as for torchrun.
+
+        Args:
+            nnodes: Number of nodes (pods)
+            nproc_per_node: GPUs per node
+            master_port: Master communication port
+            model_script: Path to model's run script (e.g. scripts/primus_pretrain/run.sh)
+            model_args: Optional extra arguments for the script (same as data.json ``args``)
+            model_name: Model id (e.g. ``primus_pretrain/torchtitan_MI300X_...``). Used to set
+                ``BACKEND`` when ``distributed.primus.backend`` is omitted; see
+                ``primus_pretrain/get_models_json.py`` naming convention.
+
+        Returns:
+            Shell snippet: exports + ``cd`` + ``bash run.sh ...``
+        """
+        manifest = getattr(self, "manifest", None)
+        primus_cfg = merged_primus_config(
+            manifest if isinstance(manifest, dict) else None,
+            self.config.additional_context,
+        )
+        config_path = primus_cfg.get("config_path", "examples/torchtitan/configs/MI300X/qwen3_1.7B-pretrain.yaml")
+        cli_extra = primus_cfg.get("cli_extra", "")
+        config_path_quoted = config_path.replace('"', '\\"')
+        lines = [
+            "# Primus launcher (run.sh → Primus examples/run_pretrain.sh)",
+            # Dockerfile uses PRIMUS_ROOT=/workspace/Primus; ConfigMap extracts Primus/… there.
+            'export PRIMUS_ROOT="${PRIMUS_ROOT:-/workspace/Primus}"',
+            f'export PRIMUS_CONFIG_PATH="{config_path_quoted}"',
+        ]
+        if (cli_extra or "").strip():
+            cli_extra_quoted = cli_extra.replace('"', '\\"')
+            lines.append(f'export PRIMUS_CLI_EXTRA="{cli_extra_quoted}"')
+        backend_override = (primus_cfg.get("backend") or "").strip()
+        backend_effective = backend_override
+        if not backend_effective and model_name:
+            backend_effective = infer_primus_backend_from_model_name(model_name) or ""
+        if backend_effective:
+            backend_quoted = backend_effective.replace('"', '\\"')
+            lines.append(f'export BACKEND="{backend_quoted}"')
+
+        if nnodes == 1:
+            lines.extend(
+                [
+                    "export MASTER_ADDR=${MASTER_ADDR:-localhost}",
+                    f"export MASTER_PORT=${{MASTER_PORT:-{master_port}}}",
+                    "export NNODES=1",
+                    "export NODE_RANK=0",
+                    f"export GPUS_PER_NODE={nproc_per_node}",
+                    f"export MAD_RUNTIME_NGPUS={nproc_per_node}",
+                ]
+            )
+        else:
+            master_dns = (
+                f"{self.job_name}-0.{self.job_name}.{self.namespace}.svc.cluster.local"
+            )
+            lines.extend(
+                [
+                    "# Multi-node: Indexed Job + headless Service (pod-0 DNS as master)",
+                    f'export MASTER_ADDR="{master_dns}"',
+                    f"export MASTER_PORT={master_port}",
+                    f"export NNODES={nnodes}",
+                    "export NODE_RANK=${JOB_COMPLETION_INDEX}",
+                    f"export GPUS_PER_NODE={nproc_per_node}",
+                    f"export MAD_RUNTIME_NGPUS={nproc_per_node}",
+                ]
+            )
+
+        script_dir = str(Path(model_script).parent)
+        script_name = str(Path(model_script).name)
+        args_tail = (model_args or "").strip()
+        if args_tail:
+            lines.append(f"cd {script_dir} && bash {script_name} {args_tail}")
+        else:
+            lines.append(f"cd {script_dir} && bash {script_name}")
+
+        return "\n".join(lines)
+

--- a/src/madengine/deployment/primus_backend.py
+++ b/src/madengine/deployment/primus_backend.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Infer Primus ``BACKEND`` from madengine model names.
+
+Convention (see ``scripts/primus_pretrain/get_models_json.py`` in MAD-internal):
+``primus_pretrain/<launcher>_<arch>_<config_stem>``, e.g.
+``primus_pretrain/torchtitan_MI300X_qwen3_4B-pretrain`` → launcher ``torchtitan``.
+
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+# Primus ``run_pretrain.sh`` / ``run.sh`` expect ``MaxText`` capitalization for JAX;
+# other backends use lowercase tokens.
+_BACKEND_BY_LAUNCHER_TOKEN = {
+    "maxtext": "MaxText",
+    "torchtitan": "torchtitan",
+    "megatron": "megatron",
+    "megatron_bridge": "megatron_bridge",
+    "moe_package": "moe_package",
+}
+
+
+def merged_primus_config(
+    manifest: Optional[Dict[str, Any]], additional_context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Merge ``distributed.primus`` from build manifest ``deployment_config`` and
+    runtime ``additional_context`` (runtime wins on key conflicts).
+    """
+    out: Dict[str, Any] = {}
+    if manifest:
+        dist = (manifest.get("deployment_config") or {}).get("distributed") or {}
+        prim = dist.get("primus") or {}
+        if isinstance(prim, dict):
+            out.update(prim)
+    ac_dist = additional_context.get("distributed") or {}
+    ac_prim = ac_dist.get("primus") or {}
+    if isinstance(ac_prim, dict):
+        out.update(ac_prim)
+    return out
+
+
+def infer_primus_examples_overlay_subdirs(
+    config_path: str,
+    *,
+    backend_hint: str = "",
+    model_name: str = "",
+) -> List[str]:
+    """
+    Which ``scripts/Primus/examples/<subdir>/`` trees to bundle for Kubernetes.
+
+    Container images often install Primus from upstream GitHub without every experiment
+    YAML that exists in a local ``scripts/Primus`` checkout. Madengine bundles the
+    matching ``examples/<backend>/`` subtree from the project directory into the
+    ConfigMap and overlays it onto ``PRIMUS_ROOT`` before running Primus.
+
+    Resolution order: path heuristics → explicit ``distributed.primus.backend`` →
+    ``primus_pretrain/...`` model name → ``torchtitan``.
+    """
+    cp = (config_path or "").replace("\\", "/").lower()
+    if "/megatron_bridge/" in cp or cp.startswith("examples/megatron_bridge/"):
+        return ["megatron_bridge"]
+    if "/moe_package/" in cp or cp.startswith("examples/moe_package/"):
+        return ["moe_package"]
+    if "/maxtext/" in cp or cp.startswith("examples/maxtext/"):
+        return ["maxtext"]
+    if "/torchtitan/" in cp or cp.startswith("examples/torchtitan/"):
+        return ["torchtitan"]
+    if "/megatron/" in cp or cp.startswith("examples/megatron/"):
+        return ["megatron"]
+
+    bh = (backend_hint or "").strip().lower()
+    if bh == "maxtext":
+        return ["maxtext"]
+    if bh in ("megatron_bridge", "moe_package", "torchtitan", "megatron"):
+        return [bh]
+
+    fb = infer_primus_backend_from_model_name(model_name) if model_name else None
+    if fb == "MaxText":
+        return ["maxtext"]
+    if fb in ("megatron_bridge", "moe_package", "torchtitan", "megatron"):
+        return [fb]
+
+    return ["torchtitan"]
+
+
+def infer_primus_backend_from_model_name(model_name: str) -> Optional[str]:
+    """
+    Return the ``BACKEND`` value to export when ``distributed.primus.backend`` is omitted.
+
+    Only handles names with the ``primus_pretrain/`` prefix and a launcher token
+    before the first ``_`` (e.g. ``torchtitan`` in ``primus_pretrain/torchtitan_MI300X_...``).
+
+    Returns:
+        The string to pass to ``export BACKEND=...``, or ``None`` if unknown / not applicable.
+    """
+    if not model_name or not model_name.strip():
+        return None
+    raw = model_name.strip()
+    prefix = "primus_pretrain/"
+    if not raw.startswith(prefix):
+        return None
+    suffix = raw[len(prefix) :].strip()
+    if not suffix:
+        return None
+    launcher_token = suffix.split("_", 1)[0].lower()
+    return _BACKEND_BY_LAUNCHER_TOKEN.get(launcher_token)

--- a/src/madengine/deployment/slurm.py
+++ b/src/madengine/deployment/slurm.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .base import BaseDeployment, DeploymentConfig, DeploymentResult, DeploymentStatus, create_jinja_env
+from .primus_backend import infer_primus_backend_from_model_name, merged_primus_config
 from .common import configure_multi_node_profiling, normalize_launcher
 from .config_loader import ConfigLoader, apply_deployment_config
 from .slurm_node_selector import SlurmNodeSelector
@@ -274,7 +275,8 @@ class SlurmDeployment(BaseDeployment):
             launcher_type=launcher_type,
             nnodes=nnodes,
             nproc_per_node=nproc_per_node,
-            master_port=master_port
+            master_port=master_port,
+            model_name=model_info.get("name", "") or "",
         )
         
         return {
@@ -317,7 +319,12 @@ class SlurmDeployment(BaseDeployment):
         }
 
     def _generate_launcher_command(
-        self, launcher_type: str, nnodes: int, nproc_per_node: int, master_port: int
+        self,
+        launcher_type: str,
+        nnodes: int,
+        nproc_per_node: int,
+        master_port: int,
+        model_name: str = "",
     ) -> str:
         """
         Generate launcher-specific command based on launcher type.
@@ -347,6 +354,10 @@ class SlurmDeployment(BaseDeployment):
             return self._generate_megatron_command(nnodes, nproc_per_node, master_port)
         elif launcher_type == "torchtitan":
             return self._generate_torchtitan_command(nnodes, nproc_per_node, master_port)
+        elif launcher_type == "primus":
+            return self._generate_primus_command(
+                nnodes, nproc_per_node, master_port, model_name=model_name
+            )
         else:
             # For unknown launchers, provide basic environment variables
             # and let the model script handle launcher invocation
@@ -636,6 +647,42 @@ export TORCHTITAN_CONTEXT_PARALLEL_SIZE=1
 
 # Use torchrun as launcher (TorchTitan built on top of it)
 export MAD_MULTI_NODE_RUNNER="torchrun --nnodes={nnodes} --nproc_per_node={nproc_per_node} --node_rank=${{NODE_RANK}} --master_addr=${{MASTER_ADDR}} --master_port={master_port}"'''
+
+    def _generate_primus_command(
+        self,
+        nnodes: int,
+        nproc_per_node: int,
+        master_port: int,
+        model_name: str = "",
+    ) -> str:
+        """
+        Generate Primus launcher environment for SLURM.
+
+        Primus (Megatron-LM, TorchTitan, Jax/MaxText) runs via model script that calls
+        run_pretrain.sh; NNODES, NODE_RANK, MASTER_ADDR, etc. are set by the job script.
+        We only export PRIMUS_CONFIG_PATH and optional PRIMUS_CLI_EXTRA. No MAD_MULTI_NODE_RUNNER.
+        """
+        primus_cfg = merged_primus_config(
+            self.manifest if isinstance(getattr(self, "manifest", None), dict) else None,
+            self.config.additional_context,
+        )
+        config_path = primus_cfg.get("config_path", "exp_pretrain.yaml")
+        cli_extra = primus_cfg.get("cli_extra", "")
+        # Safe shell quoting for config_path and cli_extra
+        config_path_quoted = config_path.replace('"', '\\"')
+        lines = [f'# Primus launcher (model script runs run_pretrain.sh)',
+                 f'export PRIMUS_CONFIG_PATH="{config_path_quoted}"']
+        if (cli_extra or "").strip():
+            cli_extra_quoted = cli_extra.replace('"', '\\"')
+            lines.append(f'export PRIMUS_CLI_EXTRA="{cli_extra_quoted}"')
+        backend_override = (primus_cfg.get("backend") or "").strip()
+        backend_effective = backend_override
+        if not backend_effective and model_name:
+            backend_effective = infer_primus_backend_from_model_name(model_name) or ""
+        if backend_effective:
+            backend_quoted = backend_effective.replace('"', '\\"')
+            lines.append(f'export BACKEND="{backend_quoted}"')
+        return "\n".join(lines)
 
     def _generate_basic_env_command(
         self, nnodes: int, nproc_per_node: int, master_port: int

--- a/src/madengine/deployment/templates/kubernetes/configmap.yaml.j2
+++ b/src/madengine/deployment/templates/kubernetes/configmap.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app: madengine
-    model: {{ model_name }}
+    model: {{ model_label }}
 data:
   build_manifest.json: |
 {{ manifest_content | indent(4, first=True) }}

--- a/src/madengine/deployment/templates/kubernetes/job.yaml.j2
+++ b/src/madengine/deployment/templates/kubernetes/job.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app: madengine
-    model: {{ model_name }}
+    model: {{ model_label }}
     madengine-job: "true"
 spec:
   {% if ttl_seconds_after_finished is not none %}
@@ -22,7 +22,7 @@ spec:
       labels:
         app: madengine
         job-name: {{ job_name }}
-        model: {{ model_name }}
+        model: {{ model_label }}
     spec:
       {% if subdomain %}
       subdomain: {{ subdomain }}
@@ -108,7 +108,7 @@ spec:
       
       # Main container runs benchmark
       containers:
-      - name: {{ job_name }}
+      - name: {{ main_container_name }}
         image: {{ image }}
         imagePullPolicy: {{ image_pull_policy }}
         workingDir: /workspace
@@ -181,7 +181,7 @@ spec:
             export MAD_K8S_JOB=true
             export MAD_DEPLOYMENT_TYPE=kubernetes
             
-            {% if launcher_type == "torchrun" or launcher_type == "deepspeed" or launcher_type == "megatron" %}
+            {% if launcher_type == "torchrun" or launcher_type == "deepspeed" or launcher_type == "megatron" or launcher_type == "primus" or launcher_type == "torchtitan" %}
             # {{ launcher_type }} distributed environment (auto-configured from K8s)
             {% if nnodes > 1 %}
             # Multi-node {{ launcher_type }} (Indexed Job)
@@ -278,6 +278,9 @@ spec:
                 echo "✓ Cleared MIOpen cache directory"
             fi
             mkdir -p "${MIOPEN_USER_DB_PATH:-/tmp/.miopen}"
+            
+            # Primus: experiment YAMLs are in the ConfigMap as Primus/examples/... and extracted
+            # to /workspace/Primus (see madengine _bundle_primus_k8s_examples_overlay); PRIMUS_ROOT=/workspace/Primus.
             
             # Create wrapper script for launcher
             echo ""

--- a/src/madengine/deployment/templates/kubernetes/service.yaml.j2
+++ b/src/madengine/deployment/templates/kubernetes/service.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ namespace }}
   labels:
     app: madengine
-    model: {{ model_name }}
+    model: {{ model_label }}
 spec:
   clusterIP: None  # Headless service for torchrun coordination
   selector:

--- a/src/madengine/deployment/templates/slurm/job.sh.j2
+++ b/src/madengine/deployment/templates/slurm/job.sh.j2
@@ -617,7 +617,9 @@ echo "  RANK (node rank): ${RANK}"
 echo "  NODE_RANK: ${NODE_RANK}"
 echo "  NNODES: ${NNODES}"
 echo "  NPROC_PER_NODE: ${GPUS_PER_NODE}"
+{% if launcher_type in ['torchrun', 'deepspeed', 'megatron'] %}
 echo "  MAD_MULTI_NODE_RUNNER: ${MAD_MULTI_NODE_RUNNER}"
+{% endif %}
 if [ "${SLURM_PROCID}" = "0" ]; then
     echo "  MAD_IS_MASTER_NODE: true (will collect performance metrics)"
 else

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -232,7 +232,7 @@ class ContainerRunner:
             "docker_file": build_info.get("dockerfile", ""),
             "base_docker": build_info.get("base_docker", ""),
             "docker_sha": build_info.get("docker_sha", ""),
-            "docker_image": build_info.get("docker_image", ""),
+            "docker_image": run_results.get("docker_image", build_info.get("docker_image", "")),
             "git_commit": run_results.get("git_commit", ""),
             "machine_name": run_results.get("machine_name", ""),
             "deployment_type": os.environ.get("MAD_DEPLOYMENT_TYPE", "local"),  # local, slurm, etc.
@@ -712,6 +712,31 @@ class ContainerRunner:
         pre_encapsulate_post_scripts["pre_scripts"].append(pre_env_details)
         print(f"pre encap post scripts: {pre_encapsulate_post_scripts}")
 
+    def _resolve_docker_image(self, docker_image: str, model_name: str) -> str:
+        """Resolve Docker image: use requested image if present, else primus_pretrain fallback with clear error."""
+        try:
+            self.console.sh(f"docker image inspect {docker_image} >/dev/null 2>&1")
+            return docker_image
+        except (subprocess.CalledProcessError, RuntimeError, Exception):
+            pass
+        if model_name.startswith("primus_pretrain/"):
+            fallback = "ci-primus_pretrain_primus.ubuntu.amd"
+            try:
+                self.console.sh(f"docker image inspect {fallback} >/dev/null 2>&1")
+                print(
+                    f"ℹ️  Using shared Primus image (one build for all primus_pretrain configs): {fallback}"
+                )
+                return fallback
+            except (subprocess.CalledProcessError, RuntimeError, Exception):
+                raise RuntimeError(
+                    f"Docker image '{docker_image}' not found and fallback '{fallback}' not found. "
+                    "Build the Primus image first: madengine build --tags primus_pretrain --additional-context-file <config>.json"
+                ) from None
+        raise RuntimeError(
+            f"Docker image '{docker_image}' not found. "
+            "Build it first: madengine build --tags <model_tag> --additional-context-file <config>.json"
+        ) from None
+
     def run_container(
         self,
         model_info: typing.Dict,
@@ -742,6 +767,9 @@ class ContainerRunner:
         """
         self.rich_console.print(f"[bold green]🏃 Running model:[/bold green] [bold cyan]{model_info['name']}[/bold cyan] [dim]in container[/dim] [yellow]{docker_image}[/yellow]")
 
+        # Resolve image: if model-specific image is missing, try shared primus_pretrain image (one build for all configs)
+        docker_image = self._resolve_docker_image(docker_image, model_info["name"])
+
         timeout = resolve_run_timeout(model_info, timeout)
         log_file_path = make_run_log_file_path(model_info, docker_image, phase_suffix)
         print(f"Run log will be written to: {log_file_path}")
@@ -765,6 +793,8 @@ class ContainerRunner:
         # If build info provided, merge it
         if build_info:
             run_results.update(build_info)
+        # Preserve actual image used (resolved, possibly fallback) for perf reporting
+        run_results["docker_image"] = docker_image
 
         # Prepare docker run options
         gpu_vendor = self.context.ctx["gpu_vendor"]
@@ -844,7 +874,10 @@ class ContainerRunner:
             'NNODES', 'NPROC_PER_NODE', 'MAD_MULTI_NODE_RUNNER',
             'MAD_COLLECT_METRICS', 'NCCL_SOCKET_IFNAME', 'GLOO_SOCKET_IFNAME',
             'NCCL_DEBUG', 'NCCL_IB_DISABLE', 'NCCL_NET_GDR_LEVEL',
-            'TORCH_ELASTIC_RDZV_TIMEOUT',  # Rendezvous timeout so all nodes can join after pull
+            # Primus launcher (config path and optional CLI extra args)
+            'PRIMUS_CONFIG_PATH', 'PRIMUS_CLI_EXTRA',
+            # Rendezvous timeout so all nodes can join after pull
+            'TORCH_ELASTIC_RDZV_TIMEOUT',
             # GPU visibility variables for Ray-based launchers (vLLM, SGLang)
             # CRITICAL: These must be passed to Docker for proper GPU device mapping
             'HIP_VISIBLE_DEVICES', 'ROCR_VISIBLE_DEVICES', 'CUDA_VISIBLE_DEVICES'
@@ -1151,11 +1184,24 @@ class ContainerRunner:
                                 pre_encapsulate_post_scripts["post_scripts"],
                             )
 
+                        # When model writes performance to a file in run_directory, copy to cwd
+                        # so the host can read it (e.g. bind-mounted workspace) before extraction.
+                        multiple_results_file = (model_info.get("multiple_results") or "").strip()
+                        if multiple_results_file:
+                            try:
+                                model_docker.sh(
+                                    f"cp {model_dir}/{multiple_results_file} . 2>/dev/null || true"
+                                )
+                            except Exception:
+                                pass
+
                         # Extract performance metrics from logs
                         # Look for performance data in the log output similar to original run_models.py
                         try:
                             # Check if multiple results file is specified in model_info
                             multiple_results = model_info.get("multiple_results", None)
+                            if multiple_results:
+                                multiple_results = multiple_results.strip()
 
                             if multiple_results:
                                 resolved_path = _resolve_multiple_results_path(

--- a/src/madengine/execution/container_runner_helpers.py
+++ b/src/madengine/execution/container_runner_helpers.py
@@ -178,6 +178,38 @@ def resolve_run_timeout(
     return cli_timeout
 
 
+def _docker_image_ref_for_log_naming(docker_image: str) -> str:
+    """
+    Reduce a Docker image reference to the same string ``DockerBuilder`` uses for tags.
+
+    Build logs use ``{model}_{dockerfile}.build.live.log`` where the image tag is
+    ``ci-{model_lower}_{dockerfile}``. Run may receive a full ref (e.g.
+    ``registry/namespace/name:ci-...``). Using the whole ref breaks pairing with
+    ``*.build.live.log`` and embeds ``/`` and ``:`` in filenames.
+
+    Rules:
+
+    - Strip digest (``@sha256:...``).
+    - If there is a ``/``, take the part after the last ``/`` (image name or
+      ``name:tag``).
+    - If that tail contains ``:``, return the tag (part after the first ``:`` in
+      the tail), which matches ``ci-...`` for normal ``repo/name:tag`` refs.
+    - Otherwise return the tail, or the whole string if there is no ``/``.
+
+    This matches short names like ``ci-model_ubuntu`` (no registry) unchanged.
+    """
+    if not docker_image:
+        return docker_image
+    s = docker_image.strip()
+    if "@" in s:
+        s = s.split("@", 1)[0]
+    last_slash = s.rfind("/")
+    tail = s[last_slash + 1 :] if last_slash >= 0 else s
+    if ":" in tail:
+        return tail.split(":", 1)[1]
+    return tail
+
+
 def make_run_log_file_path(
     model_info: typing.Dict,
     docker_image: str,
@@ -189,14 +221,19 @@ def make_run_log_file_path(
     Derives dockerfile part from image name (strip ci- and model prefix),
     then: {model_safe}_{dockerfile_part}{phase_suffix}.live.log
 
+    ``docker_image`` may be a short tag (``ci-model_ubuntu``) or a full
+    reference (``registry/repo/name:ci-model_ubuntu``); the latter is
+    normalized so run logs align with ``DockerBuilder`` / ``*.build.live.log``.
+
     Args:
         model_info: Must have "name" key.
-        docker_image: Full docker image name (e.g. ci-model_ubuntu.22.04).
+        docker_image: Docker image reference (short tag or registry/name:tag).
         phase_suffix: Optional suffix (e.g. ".run").
 
     Returns:
         Log file path string with "/" replaced by "_".
     """
+    docker_image = _docker_image_ref_for_log_naming(docker_image)
     image_name_without_ci = docker_image.replace("ci-", "")
     model_name_clean = model_info["name"].replace("/", "_").lower()
 

--- a/src/madengine/execution/docker_builder.py
+++ b/src/madengine/execution/docker_builder.py
@@ -48,6 +48,12 @@ class DockerBuilder:
     def get_context_path(self, info: typing.Dict) -> str:
         """Get the context path for Docker build.
 
+        Default is ``./docker`` (Dockerfiles that only COPY siblings under ``docker/``).
+        Primus images use ``COPY scripts/Primus/`` from the repository root; for those,
+        the context must be ``.`` so ``scripts/Primus`` is visible. Models with
+        ``dockerfile`` containing ``primus`` get repo-root context unless ``dockercontext``
+        is set explicitly.
+
         Args:
             info: The model info dict.
 
@@ -56,8 +62,10 @@ class DockerBuilder:
         """
         if "dockercontext" in info and info["dockercontext"] != "":
             return info["dockercontext"]
-        else:
-            return "./docker"
+        dockerfile_hint = (info.get("dockerfile") or "").lower()
+        if "primus" in dockerfile_hint:
+            return "."
+        return "./docker"
 
     def get_build_arg(self, run_build_arg: typing.Dict = {}) -> str:
         """Get the build arguments.

--- a/src/madengine/orchestration/run_orchestrator.py
+++ b/src/madengine/orchestration/run_orchestrator.py
@@ -567,7 +567,13 @@ class RunOrchestrator:
                 self.context.ctx["post_scripts"] = manifest_context["post_scripts"]
             if "encapsulate_script" in manifest_context:
                 self.context.ctx["encapsulate_script"] = manifest_context["encapsulate_script"]
-        
+            # Restore docker_env_vars from build context (e.g. MAD_SECRET_HFTOKEN for Primus HF-backed configs)
+            if "docker_env_vars" in manifest_context and manifest_context["docker_env_vars"]:
+                if "docker_env_vars" not in self.context.ctx:
+                    self.context.ctx["docker_env_vars"] = {}
+                for k, v in manifest_context["docker_env_vars"].items():
+                    self.context.ctx["docker_env_vars"][k] = v
+
         # Merge runtime additional_context (takes precedence over manifest)
         # This allows users to override tools/scripts at runtime
         if self.additional_context:

--- a/tests/integration/test_docker_integration.py
+++ b/tests/integration/test_docker_integration.py
@@ -122,6 +122,24 @@ class TestDockerBuilder:
     @patch.object(Context, "get_system_hip_version", return_value="5.4")
     @patch.object(Context, "get_docker_gpus", return_value="all")
     @patch.object(Context, "get_gpu_renderD_nodes", return_value=["renderD128"])
+    def test_get_context_path_primus_uses_repo_root(
+        self, mock_render, mock_docker_gpu, mock_hip, mock_arch, mock_ngpus, mock_vendor
+    ):
+        """Primus Dockerfile COPYs scripts/Primus; build context must be repo root."""
+        context = Context()
+        builder = DockerBuilder(context)
+
+        info = {"dockerfile": "docker/primus", "dockercontext": ""}
+        result = builder.get_context_path(info)
+
+        assert result == "."
+
+    @patch.object(Context, "get_gpu_vendor", return_value="AMD")
+    @patch.object(Context, "get_system_ngpus", return_value=1)
+    @patch.object(Context, "get_system_gpu_architecture", return_value="gfx908")
+    @patch.object(Context, "get_system_hip_version", return_value="5.4")
+    @patch.object(Context, "get_docker_gpus", return_value="all")
+    @patch.object(Context, "get_gpu_renderD_nodes", return_value=["renderD128"])
     def test_get_build_arg_no_args(
         self, mock_render, mock_docker_gpu, mock_hip, mock_arch, mock_ngpus, mock_vendor
     ):

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -72,6 +72,19 @@ class TestMakeRunLogFilePath:
         )
         assert out == "other_model_some_ubuntu_22.live.log"
 
+    def test_full_registry_ref_matches_short_ci_tag(self):
+        """Run log name must match build log base when image is registry/name:ci-…."""
+        model = {"name": "primus_pretrain/torchtitan_MI300X_qwen3_4B-pretrain"}
+        short = "ci-primus_pretrain_torchtitan_mi300x_qwen3_4b-pretrain_primus.ubuntu.amd"
+        full = f"rocm/mad-private:{short}"
+        assert make_run_log_file_path(model, short, ".run") == make_run_log_file_path(
+            model, full, ".run"
+        )
+        assert make_run_log_file_path(model, short, ".run") == (
+            "primus_pretrain_torchtitan_MI300X_qwen3_4B-pretrain_"
+            "primus.ubuntu.amd.run.live.log"
+        )
+
 
 # ---- dockerfile_utils ----
 

--- a/tests/unit/test_k8s.py
+++ b/tests/unit/test_k8s.py
@@ -1,10 +1,17 @@
 """
-Kubernetes-related unit tests (secrets/config helpers, PVC → pod mapping).
+Kubernetes-related unit tests (secrets/config helpers, name sanitization, PVC → pod).
 
 Keep new K8s-focused unit tests here to avoid many small `test_k8s_*.py` files.
 Integration/e2e tests stay in their own modules.
 """
 
+import pytest
+
+from madengine.deployment.k8s_names import (
+    sanitize_k8s_container_name,
+    sanitize_k8s_label_value,
+    sanitize_k8s_object_name,
+)
 from madengine.deployment.k8s_secrets import (
     CONFIGMAP_MAX_BYTES,
     SECRETS_STRATEGY_EXISTING,
@@ -154,3 +161,62 @@ def test_pvc_assign_no_duplicate_pods():
 def test_pvc_assign_empty_dirs():
     assert assign_pvc_subdirs_to_pods([], ["p"]) == {}
     assert assign_pvc_subdirs_to_pods(["  ", ""], ["p"]) == {}
+
+
+# --- Object / label / container name sanitization (k8s_names) ----------------
+
+
+@pytest.mark.unit
+class TestSanitizeK8sObjectName:
+    def test_slash_in_model_name(self):
+        name = sanitize_k8s_object_name(
+            "madengine", "primus_pretrain/torchtitan_MI300X_qwen3_1.7B-pretrain"
+        )
+        assert "/" not in name
+        assert name.startswith("madengine-")
+        assert name == "madengine-primus-pretrain-torchtitan-mi300x-qwen3-1.7b-pretrain"
+
+    def test_uppercase_and_underscore(self):
+        n = sanitize_k8s_object_name("madengine", "My_Model_NAME")
+        assert n == "madengine-my-model-name"
+
+    def test_max_length_stable_hash(self):
+        long_name = "a" * 400
+        n = sanitize_k8s_object_name("madengine", long_name)
+        assert len(n) <= 253
+        assert "/" not in n
+        n2 = sanitize_k8s_object_name("madengine", long_name)
+        assert n == n2
+
+    def test_empty_body_uses_model(self):
+        n = sanitize_k8s_object_name("madengine", "///")
+        assert "madengine" in n
+        assert "/" not in n
+
+
+@pytest.mark.unit
+class TestSanitizeK8sLabelValue:
+    def test_slash_and_length(self):
+        raw = "primus_pretrain/torchtitan_MI300X_qwen3_1.7B-pretrain"
+        v = sanitize_k8s_label_value(raw)
+        assert len(v) <= 63
+        assert "/" not in v
+
+    def test_long_value_truncated(self):
+        raw = "x" * 200
+        v = sanitize_k8s_label_value(raw)
+        assert len(v) <= 63
+
+
+@pytest.mark.unit
+class TestSanitizeK8sContainerName:
+    def test_dots_from_version_become_hyphens(self):
+        job = "madengine-primus-pretrain-torchtitan-mi300x-qwen3-1.7b-pretrain"
+        c = sanitize_k8s_container_name(job)
+        assert "." not in c
+        assert "1-7b" in c or "17" in c
+
+    def test_max_63_chars(self):
+        long_hint = "a" * 200
+        c = sanitize_k8s_container_name(long_hint)
+        assert len(c) <= 63

--- a/tests/unit/test_primus.py
+++ b/tests/unit/test_primus.py
@@ -1,0 +1,169 @@
+"""
+Primus-related unit tests: backend/overlay inference and K8s launcher command generation.
+
+Keeps Primus coverage in one module to avoid several small `test_*primus*.py` files.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from madengine.deployment.kubernetes_launcher_mixin import KubernetesLauncherMixin
+from madengine.deployment.primus_backend import (
+    infer_primus_backend_from_model_name,
+    infer_primus_examples_overlay_subdirs,
+    merged_primus_config,
+)
+
+
+# --- K8s mixin: _generate_primus_command -------------------------------------
+
+
+class _PrimusCommandHarness(KubernetesLauncherMixin):
+    """Minimal object with attributes _generate_primus_command expects."""
+
+    def __init__(self, additional_context, job_name="madengine-test", namespace="default"):
+        self.config = SimpleNamespace(additional_context=additional_context)
+        self.job_name = job_name
+        self.namespace = namespace
+
+
+@pytest.mark.unit
+class TestGeneratePrimusCommand:
+    def test_single_node_no_backend(self):
+        h = _PrimusCommandHarness(
+            {"distributed": {"primus": {"config_path": "examples/torchtitan/x.yaml"}}}
+        )
+        cmd = h._generate_primus_command(
+            1, 8, 1234, "scripts/primus_pretrain/run.sh", "--config_path z"
+        )
+        assert "PRIMUS_ROOT=" in cmd
+        assert "PRIMUS_CONFIG_PATH=" in cmd
+        assert "export BACKEND=" not in cmd
+        assert "MASTER_ADDR" in cmd
+        assert "NNODES=1" in cmd
+
+    def test_backend_inferred_from_model_name(self):
+        h = _PrimusCommandHarness(
+            {"distributed": {"primus": {"config_path": "examples/torchtitan/x.yaml"}}}
+        )
+        cmd = h._generate_primus_command(
+            1,
+            8,
+            1234,
+            "scripts/primus_pretrain/run.sh",
+            "",
+            model_name="primus_pretrain/torchtitan_MI300X_qwen3_4B-pretrain",
+        )
+        assert 'export BACKEND="torchtitan"' in cmd
+
+    def test_single_node_with_backend_override(self):
+        h = _PrimusCommandHarness(
+            {
+                "distributed": {
+                    "primus": {
+                        "config_path": "examples/maxtext/foo.yaml",
+                        "backend": "MaxText",
+                    }
+                }
+            }
+        )
+        cmd = h._generate_primus_command(1, 4, 1234, "scripts/primus_pretrain/run.sh", "")
+        assert 'export BACKEND="MaxText"' in cmd
+        assert "PRIMUS_CONFIG_PATH=" in cmd
+
+    def test_multi_node_service_dns(self):
+        h = _PrimusCommandHarness(
+            {"distributed": {"primus": {}}}, job_name="madengine-j", namespace="ns1"
+        )
+        cmd = h._generate_primus_command(2, 8, 1234, "scripts/primus_pretrain/run.sh", "")
+        assert "madengine-j-0.madengine-j.ns1.svc.cluster.local" in cmd
+        assert "JOB_COMPLETION_INDEX" in cmd
+        assert "NNODES=2" in cmd
+
+
+# --- primus_backend helpers --------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInferPrimusBackendFromModelName:
+    def test_torchtitan(self):
+        assert (
+            infer_primus_backend_from_model_name(
+                "primus_pretrain/torchtitan_MI300X_qwen3_4B-pretrain"
+            )
+            == "torchtitan"
+        )
+
+    def test_megatron(self):
+        assert (
+            infer_primus_backend_from_model_name(
+                "primus_pretrain/megatron_MI300X_some_experiment"
+            )
+            == "megatron"
+        )
+
+    def test_maxtext_capitalization(self):
+        assert (
+            infer_primus_backend_from_model_name("primus_pretrain/maxtext_MI300X_foo")
+            == "MaxText"
+        )
+
+    def test_non_primus_prefix(self):
+        assert infer_primus_backend_from_model_name("other/torchtitan_x") is None
+
+    def test_unknown_launcher(self):
+        assert (
+            infer_primus_backend_from_model_name(
+                "primus_pretrain/unknownThing_MI300X_x"
+            )
+            is None
+        )
+
+
+@pytest.mark.unit
+class TestMergedPrimusConfig:
+    def test_runtime_overrides_manifest(self):
+        manifest = {
+            "deployment_config": {
+                "distributed": {
+                    "primus": {
+                        "config_path": "examples/torchtitan/a.yaml",
+                        "backend": "megatron",
+                    }
+                }
+            }
+        }
+        ac = {"distributed": {"primus": {"config_path": "examples/torchtitan/b.yaml"}}}
+        m = merged_primus_config(manifest, ac)
+        assert m["config_path"] == "examples/torchtitan/b.yaml"
+        assert m["backend"] == "megatron"
+
+
+@pytest.mark.unit
+class TestInferPrimusExamplesOverlaySubdirs:
+    def test_from_torchtitan_path(self):
+        assert infer_primus_examples_overlay_subdirs(
+            "examples/torchtitan/configs/MI300X/qwen3_4B-pretrain.yaml"
+        ) == ["torchtitan"]
+
+    def test_megatron_bridge_before_megatron(self):
+        assert infer_primus_examples_overlay_subdirs(
+            "examples/megatron_bridge/foo.yaml"
+        ) == ["megatron_bridge"]
+
+    def test_megatron_path(self):
+        assert infer_primus_examples_overlay_subdirs(
+            "examples/megatron/configs/MI300X/x.yaml"
+        ) == ["megatron"]
+
+    def test_backend_hint_when_path_ambiguous(self):
+        assert infer_primus_examples_overlay_subdirs(
+            "custom/exp.yaml", backend_hint="maxtext"
+        ) == ["maxtext"]
+
+    def test_model_name_fallback(self):
+        assert infer_primus_examples_overlay_subdirs(
+            "unknown.yaml",
+            model_name="primus_pretrain/megatron_MI300X_x",
+        ) == ["megatron"]


### PR DESCRIPTION
Add first-class Primus launcher support for Kubernetes and SLURM: infer backend and examples overlay from model/config, sanitize Job/Service/ ConfigMap/container names (k8s_names), and extend templates and mixin command generation.

Docker: resolve repo-root build context for Primus Dockerfiles; align container run log filenames with build logs when the image is a full registry/repo:tag reference (container_runner_helpers).

Docs: launchers and k8s-config examples README.

Tests: integration (Docker context), unit coverage for execution helpers, K8s secrets/PVC/names, and consolidated Primus tests (test_primus).