### PR TITLE
Profiling: RTL_MODE for rocm_trace_lite and rtl trace --mode in wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to madengine will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- **Profiling**: `rocm_trace_lite` now sets `RTL_MODE=lite` explicitly; added tool `rocm_trace_lite_default` with `RTL_MODE=default` for A/B overhead comparison. `rtl_trace_wrapper.sh` passes `rtl trace --mode …` when `RTL_MODE` is set.
+
 ## [2.0.0] - 2026-04-09
 
 ### Overview

--- a/README.md
+++ b/README.md
@@ -464,7 +464,8 @@ madengine run --tags model \
 | `rocprofv3_memory` | Memory-bound analysis (ROCm 7.0+) | Cache hits, bandwidth |
 | `rocprofv3_communication` | Multi-GPU communication (ROCm 7.0+) | RCCL traces, inter-GPU transfers |
 | `rocprofv3_lightweight` | Minimal overhead profiling (ROCm 7.0+) | HIP and kernel traces |
-| `rocm_trace_lite` | Lightweight kernel dispatch trace (HSA, SQLite/RPD-style); wraps [`rtl trace`](https://sunway513.github.io/rocm-trace-lite/quickstart.html) via `rtl_trace_wrapper.sh` | `rocm_trace_lite_output/trace.db` (and optional `trace.json.gz`, `trace_summary.txt`) |
+| `rocm_trace_lite` | RTL **`lite`** mode — kernel dispatch trace (HSA, SQLite/RPD-style); [`rtl trace --mode lite`](https://sunway513.github.io/rocm-trace-lite/quickstart.html) via `rtl_trace_wrapper.sh` | `rocm_trace_lite_output/trace.db` (and optional `trace.json.gz`, `trace_summary.txt`) |
+| `rocm_trace_lite_default` | RTL **`default`** mode — broader dispatch coverage; higher overhead than `lite` (same outputs paths) | Same as `rocm_trace_lite` |
 | `rocblas_trace` | rocBLAS library calls | Function calls, arguments |
 | `miopen_trace` | MIOpen library calls | Conv/pooling operations |
 | `tensile_trace` | Tensile GEMM library | Matrix multiply details |
@@ -488,9 +489,9 @@ madengine provides 8 pre-configured ROCprofv3 profiles for different bottleneck 
 
 See [`examples/profiling-configs/`](examples/profiling-configs/) for ready-to-use configuration files.
 
-**rocm-trace-lite (`rocm_trace_lite`):**
+**rocm-trace-lite (`rocm_trace_lite` / `rocm_trace_lite_default`):**
 
-- madengine runs workloads under `scripts/common/tools/rtl_trace_wrapper.sh`, which invokes the `rtl` CLI (or `python3 -m rocm_trace_lite.cli`) and writes traces under `rocm_trace_lite_output/`.
+- madengine runs workloads under `scripts/common/tools/rtl_trace_wrapper.sh`, which invokes the `rtl` CLI (or `python3 -m rocm_trace_lite.cli`) with **`RTL_MODE=lite`** or **`RTL_MODE=default`** and writes traces under `rocm_trace_lite_output/`.
 - The trace **pre-script** installs the package from a **[GitHub Release wheel](https://github.com/sunway513/rocm-trace-lite/releases)** (not PyPI). By default it uses a **pinned** `linux_x86_64` wheel for reproducible installs. Set **`ROCM_TRACE_LITE_FOLLOW_LATEST=1`** to resolve the latest wheel via the GitHub API, or **`ROCM_TRACE_LITE_WHEEL_URL`** to a direct `.whl` URL for air-gapped installs or non-x86_64 platforms.
 - Choose **either** `rocm_trace_lite` **or** rocprof / `rocprofv3_*` for a given run—not both. Details: [Profiling Guide](docs/profiling.md) (section *rocm-trace-lite (RTL)*).
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -128,7 +128,7 @@ Collect comprehensive ROCm profiling data:
 
 [rocm-trace-lite](https://sunway513.github.io/rocm-trace-lite/index.html) captures GPU kernel dispatch timestamps via HSA runtime interception and writes a **SQLite** `.db` file (RPD-compatible). It does **not** use rocprofiler-sdk or rocprofiler. Use it when you want a **low-overhead** dispatch timeline without installing the full rocprofv3 stack, or alongside workflows that already rely on RPD-style SQLite.
 
-**Do not** wrap the same workload with both **rocprofv3** (or `rocprof` via `rocprof_wrapper.sh`) and **rocm_trace_lite** in one run: choose **one** primary GPU profiler.
+**Do not** wrap the same workload with both **rocprofv3** (or `rocprof` via `rocprof_wrapper.sh`) and **rocm_trace_lite** / **rocm_trace_lite_default** in one run: choose **one** primary GPU profiler.
 
 ```json
 {
@@ -138,7 +138,9 @@ Collect comprehensive ROCm profiling data:
 }
 ```
 
-**How madengine runs it:** The tool prepends `bash ../scripts/common/tools/rtl_trace_wrapper.sh` around your model command. The wrapper runs `rtl trace -o rocm_trace_lite_output/trace.db …` (see the [RTL quick start](https://sunway513.github.io/rocm-trace-lite/quickstart.html)). If `rtl` is not on `PATH` but the Python package is installed, it falls back to `python3 -m rocm_trace_lite.cli`.
+Use **`rocm_trace_lite`** for RTL **`lite`** mode (lower overhead; skips some dispatches that already carry a completion signal) or **`rocm_trace_lite_default`** for RTL **`default`** mode (broader coverage; higher overhead). Both set `RTL_MODE` for `rtl_trace_wrapper.sh`, which passes `rtl trace --mode <mode> …` when supported by your installed rocm-trace-lite. See upstream [rocm-trace-lite](https://github.com/sunway513/rocm-trace-lite) (`--mode` / profiling modes). Example: `examples/profiling-configs/rocm_trace_lite_default.json`.
+
+**How madengine runs it:** The tool prepends `bash ../scripts/common/tools/rtl_trace_wrapper.sh` around your model command. The wrapper runs `rtl trace` with `-o rocm_trace_lite_output/trace.db` and optional `--mode` from `RTL_MODE` (see the [RTL quick start](https://sunway513.github.io/rocm-trace-lite/quickstart.html)). If `rtl` is not on `PATH` but the Python package is installed, it falls back to `python3 -m rocm_trace_lite.cli`.
 
 **Installing `rocm-trace-lite` in the container:** Upstream distributes **wheels on [GitHub Releases](https://github.com/sunway513/rocm-trace-lite/releases)**, not on PyPI. The trace **pre-script** (`scripts/common/pre_scripts/trace.sh` with args `rocm_trace_lite`) installs via `pip` from a **pinned** `linux_x86_64` wheel URL by default (reproducible; bump the pin in that script when you intentionally upgrade RTL). To follow upstream’s latest release instead, set **`ROCM_TRACE_LITE_FOLLOW_LATEST=1`** (uses the GitHub API; needs `curl`). For a specific wheel, set **`ROCM_TRACE_LITE_WHEEL_URL`** to the full URL of a `.whl` file (or bake the package into the image). You need **outbound HTTPS to `github.com`** for the default or latest path unless the wheel is already present. Published wheels target **linux x86_64**; other architectures require a compatible wheel and the env override.
 
@@ -152,7 +154,7 @@ Collect comprehensive ROCm profiling data:
 | Multi-node (K8s/SLURM) | `rocprof` is upgraded to `rocprofv3` when available | Does not require `rocprofv3` on the submission host; other rocprof-family tools are omitted if `rocprofv3` is missing (see multi-node profiling behavior below) |
 | When to prefer | Deep analysis, hardware counters, Perfetto from rocprofv3 | Minimal-deps dispatch trace, RPD-compatible `.db` |
 
-**Multi-node profiling:** Multi-node runs that use **only** tools outside the rocprof/rocprofv3 family (such as `rocm_trace_lite`) keep profiling enabled even when `rocprofv3` is not installed on the machine submitting the job. If the tool list includes **rocprof** or any **`rocprofv3_*`** preset and `rocprofv3` is unavailable, those entries are dropped; if no tools remain, profiling is disabled and the usual rocprofiler-sdk installation guidance is logged.
+**Multi-node profiling:** Multi-node runs that use **only** tools outside the rocprof/rocprofv3 family (such as `rocm_trace_lite` or `rocm_trace_lite_default`) keep profiling enabled even when `rocprofv3` is not installed on the machine submitting the job. If the tool list includes **rocprof** or any **`rocprofv3_*`** preset and `rocprofv3` is unavailable, those entries are dropped; if no tools remain, profiling is disabled and the usual rocprofiler-sdk installation guidance is logged.
 
 ### ROCprofv3 - Advanced GPU Profiling
 
@@ -280,6 +282,8 @@ madengine run --tags your_model \
 # rocm-trace-lite (RTL) — not a rocprofv3 preset; do not mix with rocprof on the same run
 madengine run --tags your_model \
   --additional-context-file examples/profiling-configs/rocm_trace_lite.json
+madengine run --tags your_model \
+  --additional-context-file examples/profiling-configs/rocm_trace_lite_default.json
 ```
 
 See `examples/profiling-configs/README.md` for complete documentation.

--- a/examples/profiling-configs/README.md
+++ b/examples/profiling-configs/README.md
@@ -1,6 +1,6 @@
 # Profiling configurations
 
-This directory contains pre-configured profiling setups for madengine. Most files target **ROCprofv3**; **`rocm_trace_lite.json`** enables [rocm-trace-lite](https://github.com/sunway513/rocm-trace-lite) (not rocprofv3—do not combine with `rocprof` / `rocprofv3_*` on the same run).
+This directory contains pre-configured profiling setups for madengine. Most files target **ROCprofv3**; **`rocm_trace_lite.json`** / **`rocm_trace_lite_default.json`** enable [rocm-trace-lite](https://github.com/sunway513/rocm-trace-lite) (not rocprofv3—do not combine with `rocprof` / `rocprofv3_*` on the same run).
 
 ## Available Profiles
 
@@ -86,9 +86,12 @@ madengine run --tags your_model \
   --additional-context-file examples/profiling-configs/rocprofv3_lightweight.json
 ```
 
-### 6. rocm-trace-lite (`rocm_trace_lite.json`)
+### 6. rocm-trace-lite (`rocm_trace_lite.json`, `rocm_trace_lite_default.json`)
 
-**Use Case**: Low-overhead GPU kernel dispatch tracing without rocprofiler-sdk (SQLite output compatible with RPD-style tools). See the [rocm-trace-lite documentation](https://sunway513.github.io/rocm-trace-lite/index.html) and [Quick Start](https://sunway513.github.io/rocm-trace-lite/quickstart.html).
+**Use Case**: GPU kernel dispatch tracing without rocprofiler-sdk (SQLite output compatible with RPD-style tools). See the [rocm-trace-lite documentation](https://sunway513.github.io/rocm-trace-lite/index.html) and [Quick Start](https://sunway513.github.io/rocm-trace-lite/quickstart.html).
+
+- **`rocm_trace_lite.json`** — tool `rocm_trace_lite`: RTL **`lite`** mode (typically lower overhead).
+- **`rocm_trace_lite_default.json`** — tool `rocm_trace_lite_default`: RTL **`default`** mode (broader coverage; compare overhead vs `lite`).
 
 **Do not** combine with `rocprof` / `rocprofv3_*` on the same run.
 
@@ -102,6 +105,9 @@ madengine run --tags your_model \
 ```bash
 madengine run --tags your_model \
   --additional-context-file examples/profiling-configs/rocm_trace_lite.json
+
+madengine run --tags your_model \
+  --additional-context-file examples/profiling-configs/rocm_trace_lite_default.json
 ```
 
 ### 7. Multi-Node Distributed (`rocprofv3_multi_node.json`)
@@ -209,7 +215,7 @@ The wrapper script auto-detects which profiler is available and formats the comm
 | `rocprofv3_api_overhead` | API call analysis | HIP/HSA/marker traces with stats | Low |
 | `rocprofv3_pc_sampling` | Kernel hotspot analysis | PC sampling at 1000 Hz | Medium |
 
-**Other:** `rocm_trace_lite` — kernel dispatch SQLite trace via [rocm-trace-lite](https://sunway513.github.io/rocm-trace-lite/index.html), installed from **GitHub Release wheels** by the trace pre-script (not PyPI; see [Profiling Guide](../../docs/profiling.md)). Not a rocprofv3 preset; do not combine with `rocprof` / `rocprofv3_*` on the same run.
+**Other:** `rocm_trace_lite` (RTL **lite** mode) and `rocm_trace_lite_default` (RTL **default** mode) — kernel dispatch SQLite trace via [rocm-trace-lite](https://sunway513.github.io/rocm-trace-lite/index.html), installed from **GitHub Release wheels** by the trace pre-script (not PyPI; see [Profiling Guide](../../docs/profiling.md)). Not a rocprofv3 preset; do not combine with `rocprof` / `rocprofv3_*` on the same run.
 
 ## Counter Definition Files
 

--- a/examples/profiling-configs/rocm_trace_lite_default.json
+++ b/examples/profiling-configs/rocm_trace_lite_default.json
@@ -1,0 +1,10 @@
+{
+  "gpu_vendor": "AMD",
+  "guest_os": "UBUNTU",
+  "tools": [
+    {
+      "name": "rocm_trace_lite_default",
+      "env_vars": {}
+    }
+  ]
+}

--- a/src/madengine/scripts/common/tools.json
+++ b/src/madengine/scripts/common/tools.json
@@ -185,7 +185,27 @@
         }
       ],
       "cmd": "bash ../scripts/common/tools/rtl_trace_wrapper.sh ",
-      "env_vars": {},
+      "env_vars": {
+        "RTL_MODE": "lite"
+      },
+      "post_scripts": [
+        {
+          "path": "scripts/common/post_scripts/trace.sh",
+          "args": "rocm_trace_lite"
+        }
+      ]
+    },
+    "rocm_trace_lite_default": {
+      "pre_scripts": [
+        {
+          "path": "scripts/common/pre_scripts/trace.sh",
+          "args": "rocm_trace_lite"
+        }
+      ],
+      "cmd": "bash ../scripts/common/tools/rtl_trace_wrapper.sh ",
+      "env_vars": {
+        "RTL_MODE": "default"
+      },
       "post_scripts": [
         {
           "path": "scripts/common/post_scripts/trace.sh",

--- a/src/madengine/scripts/common/tools/counters/instruction_mix.txt
+++ b/src/madengine/scripts/common/tools/counters/instruction_mix.txt
@@ -1,0 +1,7 @@
+# Instruction mix counters for MAD-agent instruction_histogram (real data)
+# Used with rocprofv3 counter collection; output is converted to instruction_histogram.json
+pmc: SQ_INSTS_VALU
+pmc: SQ_INSTS_SALU
+pmc: SQ_INSTS_VMEM_RD
+pmc: SQ_INSTS_VMEM_WR
+pmc: SQ_WAIT_INST_ANY

--- a/src/madengine/scripts/common/tools/rtl_trace_wrapper.sh
+++ b/src/madengine/scripts/common/tools/rtl_trace_wrapper.sh
@@ -15,6 +15,9 @@
 # Environment (optional):
 #   RTL_WRAPPER_OUTPUT_DIR   Output directory (default: rocm_trace_lite_output)
 #   RTL_WRAPPER_TRACE_DB     Full path to trace DB (default: $RTL_WRAPPER_OUTPUT_DIR/trace.db)
+#   RTL_MODE                 Profiling mode passed to `rtl trace --mode` (e.g. lite, default, full).
+#                            When unset, `rtl trace` uses the RTL CLI default (version-dependent).
+#                            See: https://github.com/sunway513/rocm-trace-lite
 
 set -euo pipefail
 
@@ -25,9 +28,15 @@ mkdir -p "${RTL_OUT_DIR}"
 
 # Prefer rtl on PATH; else Python module after pip install (same entry point as rtl CLI).
 if command -v rtl >/dev/null 2>&1; then
+	if [[ -n "${RTL_MODE:-}" ]]; then
+		exec rtl trace --mode "${RTL_MODE}" -o "${RTL_DB}" "$@"
+	fi
 	exec rtl trace -o "${RTL_DB}" "$@"
 fi
 if python3 -c 'import rocm_trace_lite' 2>/dev/null; then
+	if [[ -n "${RTL_MODE:-}" ]]; then
+		exec python3 -m rocm_trace_lite.cli trace --mode "${RTL_MODE}" -o "${RTL_DB}" "$@"
+	fi
 	exec python3 -m rocm_trace_lite.cli trace -o "${RTL_DB}" "$@"
 fi
 

--- a/src/madengine/scripts/common/tools/rtl_trace_wrapper.sh
+++ b/src/madengine/scripts/common/tools/rtl_trace_wrapper.sh
@@ -15,7 +15,9 @@
 # Environment (optional):
 #   RTL_WRAPPER_OUTPUT_DIR   Output directory (default: rocm_trace_lite_output)
 #   RTL_WRAPPER_TRACE_DB     Full path to trace DB (default: $RTL_WRAPPER_OUTPUT_DIR/trace.db)
-#   RTL_MODE                 Profiling mode passed to `rtl trace --mode` (e.g. lite, default, full).
+#   RTL_MODE                 Profiling mode for `rtl trace --mode` (e.g. lite, default, full).
+#                            Used only if `rtl trace --help` (or the Python CLI --help) lists --mode;
+#                            otherwise a warning is printed and tracing runs without --mode.
 #                            When unset, `rtl trace` uses the RTL CLI default (version-dependent).
 #                            See: https://github.com/sunway513/rocm-trace-lite
 
@@ -29,13 +31,19 @@ mkdir -p "${RTL_OUT_DIR}"
 # Prefer rtl on PATH; else Python module after pip install (same entry point as rtl CLI).
 if command -v rtl >/dev/null 2>&1; then
 	if [[ -n "${RTL_MODE:-}" ]]; then
-		exec rtl trace --mode "${RTL_MODE}" -o "${RTL_DB}" "$@"
+		if rtl trace --help 2>&1 | grep -q -- '--mode'; then
+			exec rtl trace --mode "${RTL_MODE}" -o "${RTL_DB}" "$@"
+		fi
+		echo "Warning: RTL_MODE is set, but installed 'rtl trace' does not support --mode; continuing without it." >&2
 	fi
 	exec rtl trace -o "${RTL_DB}" "$@"
 fi
 if python3 -c 'import rocm_trace_lite' 2>/dev/null; then
 	if [[ -n "${RTL_MODE:-}" ]]; then
-		exec python3 -m rocm_trace_lite.cli trace --mode "${RTL_MODE}" -o "${RTL_DB}" "$@"
+		if python3 -m rocm_trace_lite.cli trace --help 2>&1 | grep -q -- '--mode'; then
+			exec python3 -m rocm_trace_lite.cli trace --mode "${RTL_MODE}" -o "${RTL_DB}" "$@"
+		fi
+		echo "Warning: RTL_MODE is set, but installed 'python3 -m rocm_trace_lite.cli trace' does not support --mode; continuing without it." >&2
 	fi
 	exec python3 -m rocm_trace_lite.cli trace -o "${RTL_DB}" "$@"
 fi

--- a/tests/unit/test_deployment.py
+++ b/tests/unit/test_deployment.py
@@ -79,6 +79,7 @@ class TestToolsIncludeRocprofFamily:
 
     def test_false_for_rocm_trace_lite(self):
         assert tools_include_rocprof_family([{"name": "rocm_trace_lite"}]) is False
+        assert tools_include_rocprof_family([{"name": "rocm_trace_lite_default"}]) is False
 
 
 class TestIsRocprofv3Available:
@@ -134,6 +135,16 @@ class TestConfigureMultiNodeProfiling:
         assert out["tools"] == tools
         assert out["per_node_collection"] is True
         logger.info.assert_called()
+
+    @patch("madengine.deployment.common.is_rocprofv3_available", return_value=False)
+    def test_multi_node_no_rocprofv3_keeps_rocm_trace_lite_default(self, _mock_avail):
+        logger = MagicMock()
+        tools = [{"name": "rocm_trace_lite_default"}]
+        out = configure_multi_node_profiling(2, tools, logger)
+        assert out["enabled"] is True
+        assert out["mode"] == "multi_node"
+        assert out["tools"] == tools
+        assert out["per_node_collection"] is True
 
     @patch("madengine.deployment.common.is_rocprofv3_available", return_value=False)
     def test_multi_node_no_rocprofv3_filters_mixed_tools(self, _mock_avail):

--- a/tests/unit/test_profiling_tools_config.py
+++ b/tests/unit/test_profiling_tools_config.py
@@ -13,13 +13,19 @@ def _tools_json() -> Path:
 
 
 def test_rocm_trace_lite_config_and_apply_tools():
-    """Shipped tools.json lists rocm_trace_lite; wrapper exists; apply_tools prepends it."""
+    """Shipped tools.json lists rocm_trace_lite (RTL_MODE=lite); wrapper exists; apply_tools prepends it."""
     with open(_tools_json(), encoding="utf-8") as f:
-        cfg = json.load(f)["tools"]["rocm_trace_lite"]
+        tools = json.load(f)["tools"]
 
+    cfg = tools["rocm_trace_lite"]
     assert "rtl_trace_wrapper.sh" in cfg["cmd"]
     assert cfg["pre_scripts"][0]["args"] == "rocm_trace_lite"
     assert cfg["post_scripts"][0]["args"] == "rocm_trace_lite"
+    assert cfg["env_vars"].get("RTL_MODE") == "lite"
+
+    cfg_default = tools["rocm_trace_lite_default"]
+    assert cfg_default["env_vars"].get("RTL_MODE") == "default"
+    assert cfg_default["cmd"] == cfg["cmd"]
 
     wrapper = get_madengine_root() / "scripts" / "common" / "tools" / "rtl_trace_wrapper.sh"
     assert wrapper.is_file()
@@ -32,14 +38,26 @@ def test_rocm_trace_lite_config_and_apply_tools():
         "encapsulate_script": "bash model_run.sh",
         "post_scripts": [],
     }
-    runner.apply_tools(pre_encap_post, {}, str(_tools_json()))
+    run_env: dict = {}
+    runner.apply_tools(pre_encap_post, run_env, str(_tools_json()))
 
     enc = pre_encap_post["encapsulate_script"]
     assert "rtl_trace_wrapper.sh" in enc
     assert "bash model_run.sh" in enc
+    assert run_env.get("RTL_MODE") == "lite"
     assert any(
         s.get("args") == "rocm_trace_lite" for s in pre_encap_post["pre_scripts"]
     )
     assert any(
         s.get("args") == "rocm_trace_lite" for s in pre_encap_post["post_scripts"]
     )
+
+    pre_encap_post2 = {
+        "pre_scripts": [],
+        "encapsulate_script": "bash model_run.sh",
+        "post_scripts": [],
+    }
+    run_env2: dict = {}
+    ctx.ctx = {"tools": [{"name": "rocm_trace_lite_default"}]}
+    runner.apply_tools(pre_encap_post2, run_env2, str(_tools_json()))
+    assert run_env2.get("RTL_MODE") == "default"


### PR DESCRIPTION
Profiling: RTL_MODE for rocm_trace_lite and rtl trace --mode in wrapper
- Set rocm_trace_lite to RTL_MODE=lite; add rocm_trace_lite_default (RTL_MODE=default) for A/B comparison
- Pass rtl trace --mode from RTL_MODE in rtl_trace_wrapper.sh
- Update docs, README, profiling-configs README, deployment and tools config tests