### PR TITLE
Fix regex pattern for performance log parsing

### DIFF
--- a/src/madengine/deployment/base.py
+++ b/src/madengine/deployment/base.py
@@ -362,13 +362,13 @@ class BaseDeployment(ABC):
         """
         import re
 
-        perf_pattern = r"performance:\s*([\d.]+)\s+(\S+)"
+        perf_pattern = r"performance:\s*([\d.]+)[/a-zA-Z]*,?\s+(\S+)"
         match = re.search(perf_pattern, log_content)
         if not match:
             return None
 
         value = float(match.group(1))
-        metric = match.group(2)
+        metric = match.group(2).rstrip(',')
 
         node_id_pattern = r"node_id:\s*(\d+)"
         node_match = re.search(node_id_pattern, log_content)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

we have (',' and ‘/s’) after the perf numbers which breaks the regex pattern matching in the madengine framework.
fixes: https://amd-hub.atlassian.net/browse/ROCM-21596

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
[Uploading pyt_davit_singlegpu_pyt_davit.ubuntu.amd.run.live.log…]()
[jax_resnet_jax_flax.ubuntu.amd.run.live.log](https://github.com/user-attachments/files/26714842/jax_resnet_jax_flax.ubuntu.amd.run.live.log)

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
