### PR TITLE
feat(discover): add short-name backward-compat matching for dir-prefixed models

### DIFF
--- a/src/madengine/utils/discover_models.py
+++ b/src/madengine/utils/discover_models.py
@@ -319,6 +319,7 @@ class DiscoverModels:
                     for model in self.models:
                         if (
                             model["name"] == model_name
+                            or model["name"].split("/")[-1] == model_name
                             or self._model_entry_has_tag(model.get("tags"), tag)
                             or tag == "all"
                         ):
@@ -329,6 +330,7 @@ class DiscoverModels:
                     for custom_model in self.custom_models:
                         if (
                             custom_model.name == model_name
+                            or custom_model.name.split("/")[-1] == model_name
                             or self._model_entry_has_tag(custom_model.tags, tag)
                             or tag == "all"
                         ):

--- a/tests/unit/test_discover_models.py
+++ b/tests/unit/test_discover_models.py
@@ -73,3 +73,63 @@ class TestScopedTags:
         dm.custom_models = []
         with pytest.raises(ValueError, match="unknown"):
             dm.select_models()
+
+
+class TestShortNameBackwardCompat:
+    """Short-name (unscoped) matching resolves dir-prefixed model names for backward compat.
+
+    After migrating from root models.json to per-directory models.json, model names gain
+    a directory prefix (e.g., ``pyt_foo`` becomes ``dir/pyt_foo``). Users should still
+    be able to reference models by their original flat name via ``--tags pyt_foo``.
+    """
+
+    def test_short_name_matches_dir_prefixed_model(self):
+        """--tags pyt_foo resolves dir/pyt_foo even without 'pyt_foo' in the tags list."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["pyt_foo"]))
+        dm.models = [
+            {"name": "dir/pyt_foo", "tags": ["inference"], "args": ""},
+            {"name": "dir/pyt_bar", "tags": ["training"], "args": ""},
+        ]
+        dm.custom_models = []
+        dm.select_models()
+        assert [m["name"] for m in dm.selected_models] == ["dir/pyt_foo"]
+
+    def test_flat_name_unaffected(self):
+        """--tags foo still resolves a root (non-prefixed) model named 'foo'."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["foo"]))
+        dm.models = [
+            {"name": "foo", "tags": [], "args": ""},
+            {"name": "bar", "tags": [], "args": ""},
+        ]
+        dm.custom_models = []
+        dm.select_models()
+        assert [m["name"] for m in dm.selected_models] == ["foo"]
+
+    def test_short_name_matches_custom_model(self):
+        """Short-name matching also works for custom models from get_models_json.py."""
+        from madengine.utils.discover_models import CustomModel
+
+        dm = DiscoverModels(args=argparse.Namespace(tags=["my_model"]))
+        dm.models = []
+        cm = CustomModel(
+            name="mydir/my_model",
+            dockerfile="../../docker/mydir",
+            scripts="run.sh",
+            tags=["perf"],
+        )
+        dm.custom_models = [cm]
+        dm.select_models()
+        assert len(dm.selected_models) == 1
+        assert dm.selected_models[0]["name"] == "mydir/my_model"
+
+    def test_scoped_tag_unaffected_by_short_name_matching(self):
+        """A scoped tag dir/model_name selects only that model, not other dirs' models
+        with the same short name."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["dirA/pyt_foo"]))
+        dm.models = [
+            {"name": "dirA/pyt_foo", "tags": [], "args": ""},
+            {"name": "dirB/pyt_foo", "tags": [], "args": ""},
+        ]
+        dm.custom_models = []
+        dm.select_models()
+        assert [m["name"] for m in dm.selected_models] == ["dirA/pyt_foo"]


### PR DESCRIPTION
### Problem

When models are defined in per-directory `scripts/<dir>/models.json` files, the discovery engine prepends `<dir>/` to each model name at load time (e.g., `pyt_foo` becomes `dir/pyt_foo`). Any existing `--tags pyt_foo` usage would silently return zero results after a MAD repository migrates from a root `models.json` to the per-directory layout — breaking users without any clear error.

### Solution

Add a short-name fallback to `select_models()` so that an unscoped tag matches against both the full name and the short name (the part after the last `/`). This is purely additive — scoped tags (`scope/tag`), tag-based matching, and root models with flat names are all unaffected.

Short-name matching is safe because the paired MAD-Internal PR enforces global short-name uniqueness via a new `test_no_duplicate_short_model_names` CI test. If a conflict is introduced, that test fails at merge time before ambiguity can reach users.

### Changes

**`src/madengine/utils/discover_models.py`**

Two conditions added in the unscoped path of `select_models()` — one for static models, one for custom models from `get_models_json.py`:

```python
# Before
model["name"] == model_name

# After
model["name"] == model_name
or model["name"].split("/")[-1] == model_name
```

**`tests/unit/test_discover_models.py`**

New class `TestShortNameBackwardCompat` with four tests:

| Test | What it verifies |
|---|---|
| `test_short_name_matches_dir_prefixed_model` | `--tags pyt_foo` resolves `dir/pyt_foo` when the tag is not in the model's tags list |
| `test_flat_name_unaffected` | `--tags foo` still resolves a root model named `"foo"` (regression guard) |
| `test_short_name_matches_custom_model` | Short-name matching applies to dynamic models from `get_models_json.py` |
| `test_scoped_tag_unaffected_by_short_name_matching` | `--tags dirA/model` still selects only `dirA/model`, not `dirB/model` with the same short name |

### Behavior

| User types | Before this PR | After this PR |
|---|---|---|
| `--tags pyt_foo` | No match (model is `dir/pyt_foo`) | Resolves `dir/pyt_foo` via short-name fallback |
| `--tags dir/pyt_foo` | Works (scoped exact match) | Still works, unchanged |
| `--tags dir/all` | Works (scoped wildcard) | Still works, unchanged |
| `--tags inference` | Matches by tag | Still matches by tag, unchanged |

### Test plan

- [ ] `pytest tests/unit/test_discover_models.py -v` — all 10 tests pass (6 existing + 4 new)
- [ ] `madengine discover --tags <old_flat_name>` against a migrated MAD-Internal — resolves to `dir/<old_flat_name>`
- [ ] `madengine discover --tags <dir>/all` — scoped discovery still works