### PR TITLE
refactor(discover): scope-based model tag selection (unscoped vs scoped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Performance log parsing**: Unified and extended the `performance:` log regex across all execution paths (`base.py`, `container_runner.py`) to correctly parse values with unit suffixes (e.g. `/s`), comma separators between the value and metric name, explicit sign prefixes (`+`/`-`), uppercase scientific notation (`E`), and leading-dot decimals (e.g. `.5`). Previously the narrow `[\d.]+` pattern silently dropped records from training scripts that emitted `performance: 14164/s, samples_per_second`-style lines. The pattern is now defined as a single module-level constant (`PERFORMANCE_LOG_PATTERN` in `deployment/base.py`) shared by both parsers.
 
+- **Model discovery — tag selection with extra args**: In the unscoped `--tags` path, tag-list matching and the `all` check incorrectly used the raw tag string (e.g. `inference:batch-size=32`) instead of the pre-colon model name (`inference`). This caused tag-based selection to silently fail whenever extra args were appended via the colon syntax. Fixed for both `models` and `custom_models` loops.
+
+- **Model discovery — cross-scope name leakage**: Unscoped tags (e.g. `--tags pyt_foo`) previously matched models in any scope via a short-name split (`model["name"].split("/")[-1]`), so `pyt_foo` would silently select `MAD/pyt_foo`. Removed the short-name backward-compat matching; an unscoped name now only matches a model whose full name equals the tag exactly.
+
+### Changed
+
+- **Model discovery — scope-based tag selection**: Replaced the `strict` mode flag on `DiscoverModels` with a cleaner scope-based rule that applies uniformly to both `madengine run` and `madengine build`:
+  - **Unscoped tag** (e.g. `--tags inference`, `--tags pyt_foo`): matches any model with that value in its `tags` field (scope-agnostic), or a model whose full name equals the tag exactly (root-only).
+  - **Scoped tag** (e.g. `--tags MAD/inference`, `--tags MAD/pyt_foo`): restricts candidates to models prefixed with `MAD/`, then matches by tag field or exact full name within that scope.
+  - `--tags all` and `--tags scope/all` continue to select all models globally or within a scope respectively.
+  - Removed `strict_discovery` parameter from `BuildOrchestrator.execute()` and the corresponding call in `RunOrchestrator._build_phase()` as they are no longer needed.
+
 ## [2.0.0] - 2026-04-09
 
 ### Overview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Model discovery — cross-scope name leakage**: Unscoped tags (e.g. `--tags pyt_foo`) previously matched models in any scope via a short-name split (`model["name"].split("/")[-1]`), so `pyt_foo` would silently select `MAD/pyt_foo`. Removed the short-name backward-compat matching; an unscoped name now only matches a model whose full name equals the tag exactly.
 
+- **E2E tests — hardware-agnostic GPU arch skip**: `test_commandline_argument_skip_gpu_arch` and its companion test now detect the current GPU architecture at runtime and inject it into the fixture's `skip_gpu_arch` list, so both tests pass on any GPU (gfx942, gfx950, etc.) without hardcoding arch names. Added `get_gpu_arch()` utility to `tests/fixtures/utils.py`.
+
+- **E2E tests — `test_docker_gpus` pre-script OOM on MI350X**: The `run_rocenv_tool.sh` system-env pre-script was being OOM-killed (exit 137) inside Docker on gfx950 nodes with 6 GPUs bound, failing a test whose purpose is only GPU binding verification. Fixed by correcting the `gen_sys_env_details` condition in `container_runner.py` — the old `or` made the context key a no-op since `generate_sys_env_details` defaults to `True` — and passing `gen_sys_env_details: False` in the test's `additional_context`.
+
 ### Changed
 
 - **Model discovery — scope-based tag selection**: Replaced the `strict` mode flag on `DiscoverModels` with a cleaner scope-based rule that applies uniformly to both `madengine run` and `madengine build`:

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -954,9 +954,11 @@ class ContainerRunner:
         if os.path.exists(tools_json_file):
             self.apply_tools(pre_encapsulate_post_scripts, run_env, tools_json_file)
 
-        # Add system environment collection script to pre_scripts (equivalent to generate_sys_env_details)
-        # This ensures distributed runs have the same system environment logging as standard runs
-        if generate_sys_env_details or self.context.ctx.get("gen_sys_env_details"):
+        # Add system environment collection script to pre_scripts
+        # Context can explicitly disable via gen_sys_env_details: false in additional_context
+        ctx_sys_env = self.context.ctx.get("gen_sys_env_details")
+        should_collect_sys_env = ctx_sys_env if ctx_sys_env is not None else generate_sys_env_details
+        if should_collect_sys_env:
             self.gather_system_env_details(
                 pre_encapsulate_post_scripts, model_info["name"]
             )

--- a/src/madengine/orchestration/build_orchestrator.py
+++ b/src/madengine/orchestration/build_orchestrator.py
@@ -261,7 +261,7 @@ class BuildOrchestrator:
         try:
             # Step 1: Discover models
             self.rich_console.print("[bold cyan]🔍 Discovering models...[/bold cyan]")
-            discover_models = DiscoverModels(args=self.args)
+            discover_models = DiscoverModels(args=self.args, strict=True)
             models = discover_models.run()
 
             if not models:

--- a/src/madengine/orchestration/build_orchestrator.py
+++ b/src/madengine/orchestration/build_orchestrator.py
@@ -261,7 +261,7 @@ class BuildOrchestrator:
         try:
             # Step 1: Discover models
             self.rich_console.print("[bold cyan]🔍 Discovering models...[/bold cyan]")
-            discover_models = DiscoverModels(args=self.args, strict=True)
+            discover_models = DiscoverModels(args=self.args)
             models = discover_models.run()
 
             if not models:

--- a/src/madengine/orchestration/image_filtering.py
+++ b/src/madengine/orchestration/image_filtering.py
@@ -94,7 +94,10 @@ def filter_images_by_skip_gpu_arch(
         skip_list = [arch.strip() for arch in skip_gpu_arch_str.split(",")]
         sys_gpu_arch = runtime_gpu_arch
         if sys_gpu_arch and "NVIDIA" in sys_gpu_arch:
-            sys_gpu_arch = sys_gpu_arch.split()[1]
+            # Normalize "NVIDIA A100-SXM4-40GB" -> "A100", "NVIDIA H100 PCIe" -> "H100"
+            # (mirrors get_gpu_arch() in tests/fixtures/utils.py)
+            after_prefix = sys_gpu_arch[sys_gpu_arch.index("NVIDIA") + len("NVIDIA ") :]
+            sys_gpu_arch = after_prefix.split("-")[0].split()[0]
 
         if sys_gpu_arch in skip_list:
             skipped.append((model_name, image_info, runtime_gpu_arch))

--- a/src/madengine/utils/discover_models.py
+++ b/src/madengine/utils/discover_models.py
@@ -47,13 +47,19 @@ class CustomModel:
 class DiscoverModels:
     """Class to discover models in the project."""
 
-    def __init__(self, args: argparse.Namespace):
+    def __init__(self, args: argparse.Namespace, strict: bool = False):
         """Initialize the DiscoverModels class.
 
         Args:
             args (argparse.Namespace): Arguments passed to the script.
+            strict (bool): When True, tag matching only uses exact full model
+                name (no cross-namespace short-name or tags-list matching).
+                Use for ``run`` to prevent ``pyt_huggingface_gpt2`` from
+                selecting ``MAD/pyt_huggingface_gpt2``. Default False
+                preserves the loose discover behaviour.
         """
         self.args = args
+        self.strict = strict
         self.rich_console = RichConsole()
         # list of models from models.json and scripts/model_dir/models.json
         self.models: typing.List[dict] = []
@@ -317,23 +323,31 @@ class DiscoverModels:
                             tag_models.append(model_dict)
                 else:
                     for model in self.models:
-                        if (
-                            model["name"] == model_name
-                            or model["name"].split("/")[-1] == model_name
-                            or self._model_entry_has_tag(model.get("tags"), tag)
-                            or tag == "all"
-                        ):
+                        if self.strict:
+                            match = model["name"] == model_name or tag == "all"
+                        else:
+                            match = (
+                                model["name"] == model_name
+                                or model["name"].split("/")[-1] == model_name
+                                or self._model_entry_has_tag(model.get("tags"), tag)
+                                or tag == "all"
+                            )
+                        if match:
                             model_dict = model.copy()
                             model_dict["args"] = model_dict["args"] + extra_args
                             tag_models.append(model_dict)
 
                     for custom_model in self.custom_models:
-                        if (
-                            custom_model.name == model_name
-                            or custom_model.name.split("/")[-1] == model_name
-                            or self._model_entry_has_tag(custom_model.tags, tag)
-                            or tag == "all"
-                        ):
+                        if self.strict:
+                            match = custom_model.name == model_name or tag == "all"
+                        else:
+                            match = (
+                                custom_model.name == model_name
+                                or custom_model.name.split("/")[-1] == model_name
+                                or self._model_entry_has_tag(custom_model.tags, tag)
+                                or tag == "all"
+                            )
+                        if match:
                             custom_model.update_model()
                             dirname = custom_model.name.split("/")[0]
                             custom_model.dockerfile = os.path.normpath(

--- a/src/madengine/utils/discover_models.py
+++ b/src/madengine/utils/discover_models.py
@@ -47,19 +47,13 @@ class CustomModel:
 class DiscoverModels:
     """Class to discover models in the project."""
 
-    def __init__(self, args: argparse.Namespace, strict: bool = False):
+    def __init__(self, args: argparse.Namespace):
         """Initialize the DiscoverModels class.
 
         Args:
             args (argparse.Namespace): Arguments passed to the script.
-            strict (bool): When True, tag matching only uses exact full model
-                name (no cross-namespace short-name or tags-list matching).
-                Use for ``run`` to prevent ``pyt_huggingface_gpt2`` from
-                selecting ``MAD/pyt_huggingface_gpt2``. Default False
-                preserves the loose discover behaviour.
         """
         self.args = args
-        self.strict = strict
         self.rich_console = RichConsole()
         # list of models from models.json and scripts/model_dir/models.json
         self.models: typing.List[dict] = []
@@ -323,31 +317,21 @@ class DiscoverModels:
                             tag_models.append(model_dict)
                 else:
                     for model in self.models:
-                        if self.strict:
-                            match = model["name"] == model_name or tag == "all"
-                        else:
-                            match = (
-                                model["name"] == model_name
-                                or model["name"].split("/")[-1] == model_name
-                                or self._model_entry_has_tag(model.get("tags"), tag)
-                                or tag == "all"
-                            )
-                        if match:
+                        if (
+                            model["name"] == model_name
+                            or self._model_entry_has_tag(model.get("tags"), tag)
+                            or tag == "all"
+                        ):
                             model_dict = model.copy()
                             model_dict["args"] = model_dict["args"] + extra_args
                             tag_models.append(model_dict)
 
                     for custom_model in self.custom_models:
-                        if self.strict:
-                            match = custom_model.name == model_name or tag == "all"
-                        else:
-                            match = (
-                                custom_model.name == model_name
-                                or custom_model.name.split("/")[-1] == model_name
-                                or self._model_entry_has_tag(custom_model.tags, tag)
-                                or tag == "all"
-                            )
-                        if match:
+                        if (
+                            custom_model.name == model_name
+                            or self._model_entry_has_tag(custom_model.tags, tag)
+                            or tag == "all"
+                        ):
                             custom_model.update_model()
                             dirname = custom_model.name.split("/")[0]
                             custom_model.dockerfile = os.path.normpath(

--- a/src/madengine/utils/discover_models.py
+++ b/src/madengine/utils/discover_models.py
@@ -319,8 +319,8 @@ class DiscoverModels:
                     for model in self.models:
                         if (
                             model["name"] == model_name
-                            or self._model_entry_has_tag(model.get("tags"), tag)
-                            or tag == "all"
+                            or self._model_entry_has_tag(model.get("tags"), model_name)
+                            or model_name == "all"
                         ):
                             model_dict = model.copy()
                             model_dict["args"] = model_dict["args"] + extra_args
@@ -329,8 +329,8 @@ class DiscoverModels:
                     for custom_model in self.custom_models:
                         if (
                             custom_model.name == model_name
-                            or self._model_entry_has_tag(custom_model.tags, tag)
-                            or tag == "all"
+                            or self._model_entry_has_tag(custom_model.tags, model_name)
+                            or model_name == "all"
                         ):
                             custom_model.update_model()
                             dirname = custom_model.name.split("/")[0]

--- a/tests/e2e/test_build_workflows.py
+++ b/tests/e2e/test_build_workflows.py
@@ -29,6 +29,7 @@ from tests.fixtures.utils import clean_test_temp_files
 from tests.fixtures.utils import DEFAULT_CLEAN_FILES
 from tests.fixtures.utils import generate_additional_context_for_machine
 from tests.fixtures.utils import get_gpu_arch
+from tests.fixtures.utils import requires_gpu
 
 
 @pytest.fixture
@@ -99,6 +100,7 @@ class TestCLIFeatures:
         if not success:
             pytest.fail("model, dummy, not found in perf_test.csv.")
 
+    @requires_gpu("skip_gpu_arch filtering requires GPU hardware to detect current architecture")
     @pytest.mark.parametrize(
         "clean_test_temp_files", [["perf_test.csv", "perf_test.html"]], indirect=True
     )
@@ -123,6 +125,7 @@ class TestCLIFeatures:
         if "Skipping model" not in output:
             pytest.fail("Enable skipping gpu arch for running model is failed.")
 
+    @requires_gpu("skip_gpu_arch filtering requires GPU hardware to detect current architecture")
     @pytest.mark.parametrize(
         "clean_test_temp_files", [["perf_test.csv", "perf_test.html"]], indirect=True
     )

--- a/tests/e2e/test_build_workflows.py
+++ b/tests/e2e/test_build_workflows.py
@@ -21,11 +21,41 @@ import pandas as pd
 import pytest
 
 # project modules
+import shutil
+
 from tests.fixtures.utils import BASE_DIR, MODEL_DIR
 from tests.fixtures.utils import global_data
 from tests.fixtures.utils import clean_test_temp_files
 from tests.fixtures.utils import DEFAULT_CLEAN_FILES
 from tests.fixtures.utils import generate_additional_context_for_machine
+from tests.fixtures.utils import get_gpu_arch
+
+
+@pytest.fixture
+def dynamic_skip_gpu_arch_model_dir(tmp_path):
+    """Create a temporary MODEL_DIR with the current GPU arch added to skip_gpu_arch."""
+    src_dir = os.path.join(os.path.dirname(__file__), "..", "fixtures", "dummy")
+    temp_model_dir = tmp_path / "dummy"
+    shutil.copytree(src_dir, temp_model_dir)
+
+    models_json_path = temp_model_dir / "models.json"
+    with open(models_json_path) as f:
+        models = json.load(f)
+
+    current_arch = get_gpu_arch()
+    for model in models:
+        if model["name"] == "dummy_skip_gpu_arch":
+            existing = model.get("skip_gpu_arch", "")
+            skip_archs = [a.strip() for a in existing.split(",") if a.strip()]
+            if current_arch and current_arch not in skip_archs:
+                skip_archs.append(current_arch)
+            model["skip_gpu_arch"] = ", ".join(skip_archs)
+            break
+
+    with open(models_json_path, "w") as f:
+        json.dump(models, f, indent=2)
+
+    return str(temp_model_dir)
 
 
 
@@ -73,11 +103,12 @@ class TestCLIFeatures:
         "clean_test_temp_files", [["perf_test.csv", "perf_test.html"]], indirect=True
     )
     def test_commandline_argument_skip_gpu_arch(
-        self, global_data, clean_test_temp_files
+        self, global_data, clean_test_temp_files, dynamic_skip_gpu_arch_model_dir
     ):
         """
         Test that skip_gpu_arch command-line argument skips GPU architecture check.
-        UPDATED: Now uses python3 -m madengine.cli.app instead of legacy mad.py
+        Uses a dynamic MODEL_DIR with the current GPU arch added to the skip list
+        so the test works on any hardware.
         """
         context = generate_additional_context_for_machine()
         output = global_data["console"].sh(
@@ -85,7 +116,7 @@ class TestCLIFeatures:
             + BASE_DIR
             + "; "
             + "MODEL_DIR="
-            + MODEL_DIR
+            + dynamic_skip_gpu_arch_model_dir
             + " "
             + f"python3 -m madengine.cli.app run --tags dummy_skip_gpu_arch --live-output --additional-context '{json.dumps(context)}'"
         )
@@ -96,11 +127,12 @@ class TestCLIFeatures:
         "clean_test_temp_files", [["perf_test.csv", "perf_test.html"]], indirect=True
     )
     def test_commandline_argument_disable_skip_gpu_arch_fail(
-        self, global_data, clean_test_temp_files
+        self, global_data, clean_test_temp_files, dynamic_skip_gpu_arch_model_dir
     ):
         """
-        Test that --disable-skip-gpu-arch fails GPU architecture check as expected.
-        UPDATED: Now uses python3 -m madengine.cli.app instead of legacy mad.py
+        Test that --disable-skip-gpu-arch overrides skip_gpu_arch and runs the model.
+        Uses the same dynamic MODEL_DIR to ensure the current arch is in the skip list,
+        then verifies --disable-skip-gpu-arch prevents skipping.
         """
         context = generate_additional_context_for_machine()
         output = global_data["console"].sh(
@@ -108,11 +140,10 @@ class TestCLIFeatures:
             + BASE_DIR
             + "; "
             + "MODEL_DIR="
-            + MODEL_DIR
+            + dynamic_skip_gpu_arch_model_dir
             + " "
             + f"python3 -m madengine.cli.app run --tags dummy_skip_gpu_arch --disable-skip-gpu-arch --live-output --additional-context '{json.dumps(context)}'"
         )
-        # Check if exception with message 'Skipping model' is thrown
         if "Skipping model" in output:
             pytest.fail("Disable skipping gpu arch for running model is failed.")
 

--- a/tests/e2e/test_run_workflows.py
+++ b/tests/e2e/test_run_workflows.py
@@ -359,7 +359,7 @@ class TestContexts:
             + "MODEL_DIR="
             + MODEL_DIR
             + " "
-            + "python3 -m madengine.cli.app run --live-output --tags dummy_gpubind --additional-context \"{'docker_gpus':'0,2-4,5-5,7'}\" "
+            + "python3 -m madengine.cli.app run --live-output --tags dummy_gpubind --additional-context \"{'docker_gpus':'0,2-4,5-5,7', 'gen_sys_env_details': False}\" "
         )
 
         gpu_nodeid_map = get_gpu_nodeid_map()

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -201,10 +201,13 @@ def is_nvidia() -> bool:
 
 
 def get_gpu_arch() -> str:
-    """Get the current GPU architecture string (e.g., 'gfx942', 'gfx950').
+    """Get the current GPU architecture identifier string.
+
+    On AMD systems, returns a GPU architecture token (e.g., 'gfx942', 'gfx950').
+    On NVIDIA systems, returns the GPU model name (e.g., 'A100', 'H100').
 
     Returns:
-        str: GPU architecture string, or empty string if detection fails.
+        str: GPU architecture/model identifier, or empty string if detection fails.
     """
     global _gpu_arch_cache
 
@@ -218,10 +221,16 @@ def get_gpu_arch() -> str:
             arch = console.sh(
                 "nvidia-smi -L | head -n1 | sed 's/(UUID: .*)//g' | sed 's/GPU 0: //g'"
             )
+            arch = arch.strip() if arch else ""
+            # Normalize "NVIDIA A100-SXM4-40GB" -> "A100", "NVIDIA H100 PCIe" -> "H100"
+            if arch.startswith("NVIDIA "):
+                arch = arch[len("NVIDIA "):].split("-")[0].split()[0]
         else:
-            rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
+            from madengine.core.constants import get_rocm_path
+            rocm_path = get_rocm_path()
             arch = console.sh(f"{rocm_path}/bin/rocminfo |grep -o -m 1 'gfx.*'")
-        _gpu_arch_cache = arch.strip() if arch else ""
+            arch = arch.strip() if arch else ""
+        _gpu_arch_cache = arch
         return _gpu_arch_cache
     except Exception:
         _gpu_arch_cache = ""

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -20,6 +20,7 @@ sys.path.insert(1, BASE_DIR)
 
 # Cache variables to avoid repeated system checks during collection
 _gpu_vendor_cache = None
+_gpu_arch_cache = None
 _gpu_nodeid_map_cache = None
 _num_gpus_cache = None
 _num_cpus_cache = None
@@ -197,6 +198,34 @@ def is_nvidia() -> bool:
         # If context creation fails during collection, assume AMD
         _gpu_vendor_cache = "AMD"
         return False
+
+
+def get_gpu_arch() -> str:
+    """Get the current GPU architecture string (e.g., 'gfx942', 'gfx950').
+
+    Returns:
+        str: GPU architecture string, or empty string if detection fails.
+    """
+    global _gpu_arch_cache
+
+    if _gpu_arch_cache is not None:
+        return _gpu_arch_cache
+
+    try:
+        from madengine.core.console import Console
+        console = Console(live_output=True)
+        if is_nvidia():
+            arch = console.sh(
+                "nvidia-smi -L | head -n1 | sed 's/(UUID: .*)//g' | sed 's/GPU 0: //g'"
+            )
+        else:
+            rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
+            arch = console.sh(f"{rocm_path}/bin/rocminfo |grep -o -m 1 'gfx.*'")
+        _gpu_arch_cache = arch.strip() if arch else ""
+        return _gpu_arch_cache
+    except Exception:
+        _gpu_arch_cache = ""
+        return _gpu_arch_cache
 
 
 def get_gpu_nodeid_map() -> dict:

--- a/tests/unit/test_discover_models.py
+++ b/tests/unit/test_discover_models.py
@@ -143,3 +143,16 @@ class TestUnscopedTagSelection:
         dm.custom_models = []
         dm.select_models()
         assert sorted(m["name"] for m in dm.selected_models) == ["MAD/pyt_foo", "root_model"]
+
+    def test_unscoped_tag_with_extra_args_matches_by_tag_field(self):
+        """--tags inference:batch-size=32 selects by tag 'inference', not 'inference:batch-size=32'."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["inference:batch-size=32"]))
+        dm.models = [
+            {"name": "pyt_foo", "tags": ["inference"], "args": ""},
+            {"name": "pyt_bar", "tags": ["training"], "args": ""},
+        ]
+        dm.custom_models = []
+        dm.select_models()
+        assert len(dm.selected_models) == 1
+        assert dm.selected_models[0]["name"] == "pyt_foo"
+        assert "--batch-size 32" in dm.selected_models[0]["args"]

--- a/tests/unit/test_discover_models.py
+++ b/tests/unit/test_discover_models.py
@@ -75,61 +75,71 @@ class TestScopedTags:
             dm.select_models()
 
 
-class TestShortNameBackwardCompat:
-    """Short-name (unscoped) matching resolves dir-prefixed model names for backward compat.
+class TestUnscopedTagSelection:
+    """Unscoped --tags only searches root-level models (no scope prefix crossing)."""
 
-    After migrating from root models.json to per-directory models.json, model names gain
-    a directory prefix (e.g., ``pyt_foo`` becomes ``dir/pyt_foo``). Users should still
-    be able to reference models by their original flat name via ``--tags pyt_foo``.
-    """
-
-    def test_short_name_matches_dir_prefixed_model(self):
-        """--tags pyt_foo resolves dir/pyt_foo even without 'pyt_foo' in the tags list."""
+    def test_unscoped_tag_matches_root_model_by_name(self):
+        """--tags pyt_foo matches a root-level model named exactly pyt_foo."""
         dm = DiscoverModels(args=argparse.Namespace(tags=["pyt_foo"]))
         dm.models = [
-            {"name": "dir/pyt_foo", "tags": ["inference"], "args": ""},
-            {"name": "dir/pyt_bar", "tags": ["training"], "args": ""},
+            {"name": "pyt_foo", "tags": [], "args": ""},
+            {"name": "pyt_bar", "tags": [], "args": ""},
         ]
         dm.custom_models = []
         dm.select_models()
-        assert [m["name"] for m in dm.selected_models] == ["dir/pyt_foo"]
+        assert [m["name"] for m in dm.selected_models] == ["pyt_foo"]
 
-    def test_flat_name_unaffected(self):
-        """--tags foo still resolves a root (non-prefixed) model named 'foo'."""
-        dm = DiscoverModels(args=argparse.Namespace(tags=["foo"]))
+    def test_unscoped_tag_matches_by_tag_field(self):
+        """--tags inference selects all root-level models with inference in their tags field."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["inference"]))
         dm.models = [
-            {"name": "foo", "tags": [], "args": ""},
-            {"name": "bar", "tags": [], "args": ""},
+            {"name": "pyt_foo", "tags": ["inference"], "args": ""},
+            {"name": "pyt_bar", "tags": ["training"], "args": ""},
         ]
         dm.custom_models = []
         dm.select_models()
-        assert [m["name"] for m in dm.selected_models] == ["foo"]
+        assert [m["name"] for m in dm.selected_models] == ["pyt_foo"]
 
-    def test_short_name_matches_custom_model(self):
-        """Short-name matching also works for custom models from get_models_json.py."""
-        from madengine.utils.discover_models import CustomModel
-
-        dm = DiscoverModels(args=argparse.Namespace(tags=["my_model"]))
-        dm.models = []
-        cm = CustomModel(
-            name="mydir/my_model",
-            dockerfile="../../docker/mydir",
-            scripts="run.sh",
-            tags=["perf"],
-        )
-        dm.custom_models = [cm]
-        dm.select_models()
-        assert len(dm.selected_models) == 1
-        assert dm.selected_models[0]["name"] == "mydir/my_model"
-
-    def test_scoped_tag_unaffected_by_short_name_matching(self):
-        """A scoped tag dir/model_name selects only that model, not other dirs' models
-        with the same short name."""
-        dm = DiscoverModels(args=argparse.Namespace(tags=["dirA/pyt_foo"]))
+    def test_unscoped_tag_does_not_cross_scope_boundary(self):
+        """--tags pyt_foo must NOT match MAD/pyt_foo — scopes are not crossed."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["pyt_foo"]))
         dm.models = [
-            {"name": "dirA/pyt_foo", "tags": [], "args": ""},
-            {"name": "dirB/pyt_foo", "tags": [], "args": ""},
+            {"name": "MAD/pyt_foo", "tags": ["inference"], "args": ""},
+        ]
+        dm.custom_models = []
+        with pytest.raises(ValueError):
+            dm.select_models()
+
+    def test_unscoped_tag_matches_scoped_models_by_tag_field(self):
+        """--tags inference matches any model carrying that tag, regardless of scope prefix.
+        Tag-list matching is always scope-agnostic; only name-based matching is scope-strict."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["inference"]))
+        dm.models = [
+            {"name": "MAD/pyt_foo", "tags": ["inference"], "args": ""},
+            {"name": "MAD/pyt_bar", "tags": ["inference"], "args": ""},
         ]
         dm.custom_models = []
         dm.select_models()
-        assert [m["name"] for m in dm.selected_models] == ["dirA/pyt_foo"]
+        assert sorted(m["name"] for m in dm.selected_models) == ["MAD/pyt_bar", "MAD/pyt_foo"]
+
+    def test_unscoped_all_selects_every_model(self):
+        """--tags all selects every model regardless of scope."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["all"]))
+        dm.models = [
+            {"name": "pyt_foo", "tags": [], "args": ""},
+            {"name": "MAD/pyt_bar", "tags": [], "args": ""},
+        ]
+        dm.custom_models = []
+        dm.select_models()
+        assert sorted(m["name"] for m in dm.selected_models) == ["MAD/pyt_bar", "pyt_foo"]
+
+    def test_unscoped_tag_matches_root_and_scoped_by_tag_field(self):
+        """--tags inference selects root AND scoped models that carry that tag."""
+        dm = DiscoverModels(args=argparse.Namespace(tags=["inference"]))
+        dm.models = [
+            {"name": "root_model", "tags": ["inference"], "args": ""},
+            {"name": "MAD/pyt_foo", "tags": ["inference"], "args": ""},
+        ]
+        dm.custom_models = []
+        dm.select_models()
+        assert sorted(m["name"] for m in dm.selected_models) == ["MAD/pyt_foo", "root_model"]

--- a/tests/unit/test_discover_models.py
+++ b/tests/unit/test_discover_models.py
@@ -76,7 +76,8 @@ class TestScopedTags:
 
 
 class TestUnscopedTagSelection:
-    """Unscoped --tags only searches root-level models (no scope prefix crossing)."""
+    """Unscoped --tags: name-based matching is root-only (no scope prefix crossing),
+    but tag-field matching is scope-agnostic and can select models in any scope."""
 
     def test_unscoped_tag_matches_root_model_by_name(self):
         """--tags pyt_foo matches a root-level model named exactly pyt_foo."""


### PR DESCRIPTION
## Summary

Refines how `--tags` select models in discovery so that **scoping is driven by the tag shape** (unscoped vs `Scope/...`), instead of a `strict` flag or short-name suffix matching across scopes.

## Behavior

- **Unscoped tags** (e.g. `inference`, `pyt_foo`): match models via the tag list, or by **exact name among root-level (unscoped) models** only. They do **not** follow into a scoped tree via `name.split("/")[-1]`.
- **Scoped tags** (e.g. `MAD/inference`, `MAD/pyt_foo`): restrict candidates to the given scope, then match by tag list or **full name** as before.

This **restores loose `madengine run --tags <tag>` selection** (tag-list / root-level naming) while **stopping accidental selection of `MAD/...` or `MAD-private/...` models** from a bare unscoped tag.

## Implementation notes

- Removes the `strict` parameter and related plumbing from `BuildOrchestrator` / `RunOrchestrator` (no `strict_discovery`).
- Updates unit tests for unscoped tag selection and scope boundaries.

## Test plan

- [ ] `madengine discover` / `run` with unscoped and scoped tags cover expected models only.
- [ ] Unit: `tests/unit/test_discover_models.py`