### PR TITLE
fix(csv): strip whitespace from CSV fieldnames parsing multiple_results

### DIFF
--- a/src/madengine/deployment/kubernetes.py
+++ b/src/madengine/deployment/kubernetes.py
@@ -3282,6 +3282,7 @@ class KubernetesDeployment(KubernetesLauncherMixin, BaseDeployment):
             try:
                 with open(csv_path, "r", encoding="utf-8", errors="ignore") as f:
                     reader = csv_module.DictReader(f)
+                    reader.fieldnames = [f.strip() for f in (reader.fieldnames or [])]
                     if not reader.fieldnames or "performance" not in reader.fieldnames or "metric" not in reader.fieldnames:
                         continue
                     for row_idx, row in enumerate(reader):

--- a/src/madengine/deployment/slurm.py
+++ b/src/madengine/deployment/slurm.py
@@ -1504,7 +1504,8 @@ export MASTER_PORT={master_port}
         try:
             with open(perf_file, "r") as f:
                 reader = csv.DictReader(f)
-                rows = list(reader)
+                reader.fieldnames = [f.strip() for f in (reader.fieldnames or [])]
+                rows = [{k.strip(): v for k, v in row.items() if k} for row in reader]
             if session_start_row is not None and session_start_row < len(rows):
                 rows = rows[session_start_row:]
             elif session_start_row is not None and session_start_row >= len(rows):

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -1249,7 +1249,10 @@ class ContainerRunner:
                                         import csv
                                         with open(resolved_path, "r") as f:
                                             csv_reader = csv.DictReader(f)
-                                            
+
+                                            # Strip whitespace from fieldnames to handle headers like "model, performance, metric"
+                                            csv_reader.fieldnames = [f.strip() for f in csv_reader.fieldnames]
+
                                             # Check if 'performance' column exists
                                             if 'performance' not in csv_reader.fieldnames:
                                                 print("Error: 'performance' column not found in multiple results file.")


### PR DESCRIPTION
CSV headers written with spaces after commas (e.g. "model, performance, metric")
    cause DictReader to parse fieldnames with leading spaces, making column lookups
    like 'performance' not in fieldnames fail silently and report no metrics.

    Strip fieldnames at read time in all three execution paths:
    - container_runner.py: Docker local execution
    - kubernetes.py: K8s remote CSV parsing (fieldnames check path)
    - slurm.py: SLURM perf.csv parsing (also strips row keys, which were unstripped)