### PR TITLE
fix(rocm): clean up MAD_ROCM_PATH/ROCM_PATH dual-key flow

### DIFF
--- a/src/madengine/cli/validators.py
+++ b/src/madengine/cli/validators.py
@@ -125,11 +125,11 @@ def validate_additional_context_structure(context: Dict[str, Any]) -> None:
         _fail_structure("docker_env_vars", "an object")
 
     dev = context.get("docker_env_vars")
-    if isinstance(dev, dict) and "MAD_ROCM_PATH" in dev:
-        v = dev["MAD_ROCM_PATH"]
+    if isinstance(dev, dict) and "ROCM_PATH" in dev:
+        v = dev["ROCM_PATH"]
         if not isinstance(v, (str, type(None))):
             _fail_structure(
-                "docker_env_vars['MAD_ROCM_PATH']",
+                "docker_env_vars['ROCM_PATH']",
                 "a string (container ROCm root override)",
             )
 

--- a/src/madengine/core/context.py
+++ b/src/madengine/core/context.py
@@ -284,7 +284,8 @@ class Context:
             self.ctx["rocm_path"] = self._rocm_path
             # In-container ROCM_PATH is finalized at run time in run_container
             # via finalize_container_rocm_path (OCI env → probe → default).
-            # MAD_ROCM_PATH in docker_env_vars is consumed there, not here.
+            # docker_env_vars.ROCM_PATH (user-supplied) is preserved here; finalize
+            # normalizes it at run time. Auto-detection runs in finalize when absent.
 
             if "MAD_SYSTEM_NGPUS" not in self.ctx["docker_env_vars"]:
                 self.ctx["docker_env_vars"][

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -81,10 +81,12 @@ def _print_run_env_table(
     if "AMD" in gpu_vendor:
         # ── Host side ──────────────────────────────────────────────
         host_rocm_root = getattr(context, "_rocm_path", None) or "unknown"
+        _host_rocm_path = Path(host_rocm_root)
         host_install_type = (
             "therock"
-            if is_therock_tree(Path(host_rocm_root))
-            else "apt install"
+            if _host_rocm_path.is_dir() and is_therock_tree(_host_rocm_path)
+            else "apt install" if _host_rocm_path.is_dir()
+            else "unknown"
         )
         try:
             host_rocm_ver = context._get_tool_manager().get_version() or "unknown"
@@ -113,7 +115,7 @@ def _print_run_env_table(
         ctr_rocm_ver = _sh(
             "rocm-sdk version 2>/dev/null "
             "|| cat \"${ROCM_PATH:-/opt/rocm}/.info/version\" 2>/dev/null "
-            "|| rocminfo 2>/dev/null | grep -i 'ROCm Version' | head -n1 | grep -oP '[\\d.]+' 2>/dev/null "
+            "|| rocminfo 2>/dev/null | grep -i 'ROCm Version' | head -n1 | sed 's/.*[Vv]ersion:[[:space:]]*//;s/[[:space:]].*//;s/[^0-9.]//g' 2>/dev/null "
             "|| echo unknown"
         )
 
@@ -131,13 +133,13 @@ def _print_run_env_table(
                 return "unknown"
 
         host_cuda_root = _host_sh(
-            "nvcc --version 2>/dev/null | grep -oP 'release \\K[\\d.]+' | head -1 | "
+            "nvcc --version 2>/dev/null | sed -n 's/.*release \\([0-9][0-9.]*\\).*/\\1/p' | head -1 | "
             "xargs -I{} dirname $(which nvcc 2>/dev/null) 2>/dev/null | xargs dirname 2>/dev/null "
             "|| echo \"${CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}\""
         )
         host_cuda_ver = _host_sh(
-            "nvcc --version 2>/dev/null | grep -oP 'release \\K[\\d.]+' | head -1 "
-            "|| nvidia-smi 2>/dev/null | grep -oP 'CUDA Version: \\K[\\d.]+' | head -1 "
+            "nvcc --version 2>/dev/null | sed -n 's/.*release \\([0-9][0-9.]*\\).*/\\1/p' | head -1 "
+            "|| nvidia-smi 2>/dev/null | sed -n 's/.*CUDA Version: \\([0-9][0-9.]*\\).*/\\1/p' | head -1 "
             "|| echo unknown"
         )
 
@@ -147,8 +149,8 @@ def _print_run_env_table(
             "|| echo \"${CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}\""
         )
         ctr_cuda_ver = _sh(
-            "nvcc --version 2>/dev/null | grep -oP 'release \\K[\\d.]+' | head -1 "
-            "|| nvidia-smi 2>/dev/null | grep -oP 'CUDA Version: \\K[\\d.]+' | head -1 "
+            "nvcc --version 2>/dev/null | sed -n 's/.*release \\([0-9][0-9.]*\\).*/\\1/p' | head -1 "
+            "|| nvidia-smi 2>/dev/null | sed -n 's/.*CUDA Version: \\([0-9][0-9.]*\\).*/\\1/p' | head -1 "
             "|| echo unknown"
         )
 
@@ -1059,17 +1061,25 @@ class ContainerRunner:
         ) != -1:
             from madengine.utils.rocm_path_resolver import finalize_container_rocm_path
 
-            # Clear any ROCM_PATH left from a previous model run so finalize always
-            # re-resolves per docker_image (OCI config → probe → default).
-            # ROCM_PATH is program-managed; users override via MAD_ROCM_PATH in
-            # additional_context.docker_env_vars, which was merged just above and
-            # will be consumed by finalize_container_rocm_path correctly.
-            self.context.ctx["docker_env_vars"].pop("ROCM_PATH", None)
+            # Determine whether the user explicitly supplied ROCM_PATH for the container.
+            # If they did (via docker_env_vars.ROCM_PATH in additional_context), the
+            # re-merge above already restored it — keep it so finalize uses it directly.
+            # If they did not, clear any ROCM_PATH left from a previous model run so
+            # finalize always re-resolves for the current docker_image (OCI config →
+            # in-image probe → /opt/rocm default).
+            user_supplied_rocm_path = (
+                str(
+                    (self.additional_context or {})
+                    .get("docker_env_vars", {})
+                    .get("ROCM_PATH", "")
+                ).strip()
+            )
+            if not user_supplied_rocm_path:
+                self.context.ctx["docker_env_vars"].pop("ROCM_PATH", None)
 
             finalize_container_rocm_path(
                 self.context.ctx["docker_env_vars"],
                 docker_image,
-                self.context._rocm_path,
             )
 
         if "data" in model_info and model_info["data"] != "" and self.data:

--- a/src/madengine/utils/rocm_path_resolver.py
+++ b/src/madengine/utils/rocm_path_resolver.py
@@ -22,14 +22,12 @@ fails the root check).
 
 **Container** (``docker_env_vars``) — set when the run uses Docker (``run_container``):
 
-* ``MAD_ROCM_PATH`` in ``docker_env_vars`` — in-image ROCm root; the key is consumed and
-  mapped to ``ROCM_PATH`` inside the container. ``ROCM_PATH`` itself is program-managed
-  and should not be set directly by users.
-* Full in-container resolution order is implemented in
-  :func:`finalize_container_rocm_path` (no host mirroring): (1) ``MAD_ROCM_PATH`` override,
-  (2) ``ROCM_PATH`` / ``ROCM_HOME`` from ``docker image inspect`` OCI ``Config.Env``,
-  (3) ``docker run --rm`` with an in-image shell probe aligned with
-  :class:`RocmPathResolver` heuristics, (4) default ``/opt/rocm`` with a warning.
+* Set ``ROCM_PATH`` in ``docker_env_vars`` to pin the in-container ROCm root explicitly.
+  When absent, :func:`finalize_container_rocm_path` auto-resolves: (1) ``ROCM_PATH`` /
+  ``ROCM_HOME`` from ``docker image inspect`` OCI ``Config.Env``, (2) ``docker run --rm``
+  with an in-image shell probe aligned with :class:`RocmPathResolver` heuristics,
+  (3) default ``/opt/rocm`` with a warning. The host-resolved path is **not** mirrored
+  into the container.
 """
 
 from __future__ import annotations
@@ -374,63 +372,30 @@ def infer_rocm_path_via_docker_run(
     return line
 
 
-def apply_container_rocm_path_overrides(
-    docker_env: Dict[str, Any], host_path: str
-) -> Optional[str]:
-    """
-    Map ``MAD_ROCM_PATH`` to ``ROCM_PATH`` and normalize a user ``ROCM_PATH`` in
-    ``docker_env``. Does **not** set ``ROCM_PATH`` from the host; see
-    :func:`finalize_container_rocm_path` for run-time resolution.
-
-    Returns the resolved path if one was set, else ``None``.
-    """
-    d = docker_env
-    if MAD_ROCM_PATH in d:
-        s = d.pop(MAD_ROCM_PATH)  # always consume, even when None/blank
-        if isinstance(s, (int, float)):
-            s = str(s)
-        if not isinstance(s, str) or not str(s).strip():
-            # None/blank means "unset" — do not mirror host into container
-            return None
-        croot = normalize_rocm_path(str(s).strip())
-    elif d.get("ROCM_PATH") not in (None, "") and str(d.get("ROCM_PATH", "")).strip():
-        croot = normalize_rocm_path(str(d["ROCM_PATH"]).strip())
-    else:
-        return None
-    d["ROCM_PATH"] = croot
-    return croot
-
-
 def finalize_container_rocm_path(
     docker_env: Dict[str, Any],
     docker_image: str,
-    host_path: str,
     *,
     log: Callable[[str], None] = print,
 ) -> str:
     """
     Set ``docker_env['ROCM_PATH']`` for container workloads (AMD Docker runs).
 
-    Precedence:
+    Callers set ``docker_env['ROCM_PATH']`` directly to override (user-supplied).
+    When absent or empty, this function auto-resolves in order:
 
-    1. If ``ROCM_PATH`` is already in ``docker_env`` (e.g. from
-       :func:`apply_container_rocm_path_overrides`), use it.
-    2. Else if OCI :envvar:`ROCM_PATH` / :envvar:`ROCM_HOME` is set on the image, use
-       that (``docker image inspect``).
-    3. Else log a short warning, run the in-image shell probe, use its output if
-       successful.
-    4. Else default to ``/opt/rocm`` and log a warning.
-
-    ``host_path`` is reserved for callers that need a fallback; it is **not** used
-    for mirroring unless future policy adds an explicit opt-in.
+    1. ``ROCM_PATH`` already in ``docker_env`` (user-supplied via
+       ``docker_env_vars.ROCM_PATH`` in additional context) — normalize and use it.
+    2. OCI :envvar:`ROCM_PATH` / :envvar:`ROCM_HOME` baked into the image config
+       (``docker image inspect``).
+    3. In-image shell probe (``docker run --rm``) aligned with
+       :class:`RocmPathResolver` heuristics.
+    4. Default ``/opt/rocm`` with a warning.
     """
     d = docker_env
-    # Re-run overrides so ``docker_env_vars`` merged in ``run_container`` (late) still
-    # maps ``MAD_ROCM_PATH`` to ``ROCM_PATH`` and consumes the ``MAD_`` key.
-    apply_container_rocm_path_overrides(d, host_path)
 
     existing = d.get("ROCM_PATH")
-    if existing not in (None, ""):
+    if existing not in (None, "") and str(existing).strip():
         croot = normalize_rocm_path(str(existing).strip())
         d["ROCM_PATH"] = croot
         return croot
@@ -447,7 +412,7 @@ def finalize_container_rocm_path(
     log(
         f"Warning: image {docker_image!r} has no ROCM_PATH/ROCM_HOME in OCI Config.Env; "
         f"probing in-container for ROCm root (docker run --rm). "
-        f"Set docker_env_vars.MAD_ROCM_PATH to skip."
+        f"Set docker_env_vars.ROCM_PATH to skip."
     )
     probed = infer_rocm_path_via_docker_run(docker_image, log=log)
     if probed:
@@ -460,7 +425,7 @@ def finalize_container_rocm_path(
     d["ROCM_PATH"] = croot
     log(
         "Warning: could not infer ROCm in container; defaulting ROCM_PATH to "
-        f"{croot} (set docker_env_vars.MAD_ROCM_PATH if wrong)."
+        f"{croot} (set docker_env_vars.ROCM_PATH if wrong)."
     )
     return croot
 

--- a/tests/unit/test_rocm_path.py
+++ b/tests/unit/test_rocm_path.py
@@ -11,7 +11,6 @@ from madengine.core.constants import get_rocm_path
 from madengine.utils import rocm_path_resolver as rpr
 from madengine.utils.rocm_path_resolver import (
     MAD_ROCM_PATH,
-    apply_container_rocm_path_overrides,
     auto_detect_rocm_path,
     finalize_container_rocm_path,
     get_rocm_path_legacy,
@@ -89,8 +88,8 @@ class TestContextRocmPath:
             # Host path is not mirrored into docker_env_vars.ROCM_PATH at init.
             assert ctx.ctx["docker_env_vars"].get("ROCM_PATH") in (None, "")
 
-    def test_context_container_mad_overrides_host(self):
-        """docker_env_vars MAD_ROCM_PATH is preserved at context init; consumed at run time."""
+    def test_context_container_rocm_path_preserved_at_init(self):
+        """docker_env_vars.ROCM_PATH is preserved at context init; finalize normalizes at run time."""
         from madengine.core.context import Context
         from unittest.mock import patch
         from madengine.utils.rocm_path_resolver import normalize_rocm_path
@@ -98,7 +97,7 @@ class TestContextRocmPath:
         ac = repr(
             {
                 MAD_ROCM_PATH: "/on/host",
-                "docker_env_vars": {MAD_ROCM_PATH: "/in/image"},
+                "docker_env_vars": {"ROCM_PATH": "/in/image"},
             }
         )
         with patch.object(Context, "get_gpu_vendor", return_value="AMD"), \
@@ -110,10 +109,8 @@ class TestContextRocmPath:
              patch.object(Context, "get_gpu_renderD_nodes", return_value=None):
             ctx = Context(additional_context=ac)
         assert ctx._rocm_path == normalize_rocm_path("/on/host")
-        # ROCM_PATH is set at run time by finalize_container_rocm_path, not at context init.
-        assert ctx.ctx["docker_env_vars"].get("ROCM_PATH") is None
-        # MAD_ROCM_PATH stays in docker_env_vars until consumed by finalize at run time.
-        assert ctx.ctx["docker_env_vars"].get(MAD_ROCM_PATH) == "/in/image"
+        # User-supplied ROCM_PATH is kept in docker_env_vars at init; finalize normalizes at run time.
+        assert ctx.ctx["docker_env_vars"].get("ROCM_PATH") == "/in/image"
 
 
 @pytest.mark.unit
@@ -151,41 +148,42 @@ class TestResolveHostContainerRocmPath:
         p2 = resolve_host_rocm_path({})
         assert p2 == os.path.abspath("/env/ro").rstrip(os.sep)
 
-    def test_resolve_container_mad_consumes_key(self):
-        d = {MAD_ROCM_PATH: "/in/container"}
-        host = "/on/host"
-        r = apply_container_rocm_path_overrides(d, host)
-        assert r == os.path.abspath("/in/container").rstrip(os.sep)
-        assert d.get("ROCM_PATH") == r
-        assert MAD_ROCM_PATH not in d
-
-    def test_apply_overrides_does_not_mirror_host(self):
-        d = {}
-        r = apply_container_rocm_path_overrides(d, "/hostpath")
-        assert r is None
-        assert "ROCM_PATH" not in d
-
-    def test_apply_overrides_null_mad_rocm_path_does_not_mirror_host(self):
-        # MAD_ROCM_PATH: null/blank should be treated as "unset", not mirror host
-        for blank in (None, "", "   "):
-            d = {MAD_ROCM_PATH: blank}
-            r = apply_container_rocm_path_overrides(d, "/hostpath")
-            assert r is None, f"Expected None for MAD_ROCM_PATH={blank!r}, got {r!r}"
-            assert MAD_ROCM_PATH not in d, "Key should be consumed even when blank"
-            assert "ROCM_PATH" not in d, "Host path must not be mirrored into container"
-
     def test_get_rocm_path_legacy_alias(self, monkeypatch):
         monkeypatch.delenv("ROCM_PATH", raising=False)
         g = get_rocm_path_legacy(None)
         assert g == os.path.abspath("/opt/rocm").rstrip(os.sep)
 
-    def test_finalize_prefers_oci(self, monkeypatch):
+    # ── Container path: docker_env_vars.ROCM_PATH direct interface ────────────
+
+    def test_finalize_uses_user_supplied_rocm_path(self, monkeypatch):
+        """User-supplied ROCM_PATH in docker_env_vars is normalized and used directly."""
+        monkeypatch.setattr(
+            "madengine.utils.rocm_path_resolver.rocm_path_from_docker_image_config",
+            lambda _img: "/should/not/be/used",
+        )
+        d = {"ROCM_PATH": "/user/supplied/rocm"}
+        p = finalize_container_rocm_path(d, "x:latest", log=lambda _s: None)
+        assert p == normalize_rocm_path("/user/supplied/rocm")
+        assert d["ROCM_PATH"] == p
+
+    def test_finalize_user_rocm_path_whitespace_only_falls_through(self, monkeypatch):
+        """Whitespace-only ROCM_PATH is treated as unset; OCI detection runs."""
+        monkeypatch.setattr(
+            "madengine.utils.rocm_path_resolver.rocm_path_from_docker_image_config",
+            lambda _img: "/opt/from/oci",
+        )
+        d = {"ROCM_PATH": "   "}
+        p = finalize_container_rocm_path(d, "x:latest", log=lambda _s: None)
+        assert p == normalize_rocm_path("/opt/from/oci")
+
+    def test_finalize_prefers_oci_when_no_user_rocm_path(self, monkeypatch):
+        """Without user-supplied ROCM_PATH, OCI image config is the next source."""
         monkeypatch.setattr(
             "madengine.utils.rocm_path_resolver.rocm_path_from_docker_image_config",
             lambda _img: "/opt/from/oci",
         )
         d = {}
-        p = finalize_container_rocm_path(d, "x:latest", "/h", log=lambda _s: None)
+        p = finalize_container_rocm_path(d, "x:latest", log=lambda _s: None)
         assert p == normalize_rocm_path("/opt/from/oci")
         assert d["ROCM_PATH"] == p
 
@@ -199,10 +197,10 @@ class TestResolveHostContainerRocmPath:
             lambda _img, log=None: "/opt/probed",
         )
         d = {}
-        p = finalize_container_rocm_path(d, "x:latest", "/h", log=lambda _s: None)
+        p = finalize_container_rocm_path(d, "x:latest", log=lambda _s: None)
         assert p == normalize_rocm_path("/opt/probed")
 
-    def test_finalize_defaults(self, monkeypatch):
+    def test_finalize_defaults_to_opt_rocm(self, monkeypatch):
         monkeypatch.setattr(
             "madengine.utils.rocm_path_resolver.rocm_path_from_docker_image_config",
             lambda _img: None,
@@ -212,7 +210,22 @@ class TestResolveHostContainerRocmPath:
             lambda _img, log=None: None,
         )
         d = {}
-        p = finalize_container_rocm_path(d, "x:latest", "/h", log=lambda _s: None)
+        p = finalize_container_rocm_path(d, "x:latest", log=lambda _s: None)
+        assert p == normalize_rocm_path("/opt/rocm")
+
+    def test_finalize_host_not_mirrored_into_container(self, monkeypatch):
+        """Without user-supplied ROCM_PATH, host path is never injected into container."""
+        monkeypatch.setattr(
+            "madengine.utils.rocm_path_resolver.rocm_path_from_docker_image_config",
+            lambda _img: None,
+        )
+        monkeypatch.setattr(
+            "madengine.utils.rocm_path_resolver.infer_rocm_path_via_docker_run",
+            lambda _img, log=None: None,
+        )
+        d = {}
+        p = finalize_container_rocm_path(d, "x:latest", log=lambda _s: None)
+        # Falls back to /opt/rocm, not the host path
         assert p == normalize_rocm_path("/opt/rocm")
 
 


### PR DESCRIPTION
Host resolution: MAD_ROCM_PATH in additional_context (top-level) overrides auto-detection; falls back to ROCM_PATH env then /opt/rocm (unchanged).

Container resolution (Option C): users now set docker_env_vars.ROCM_PATH directly instead of docker_env_vars.MAD_ROCM_PATH. The old consume-translate pattern (pop MAD_ROCM_PATH → set ROCM_PATH) and apply_container_rocm_path_overrides are removed. finalize_container_rocm_path() signature drops the unused host_path parameter. A per-model-run sentinel in run_container() detects whether the user supplied ROCM_PATH explicitly; if not, any stale value from a previous run is cleared so finalize re-resolves (OCI inspect → docker-run probe → /opt/rocm).

Also fixes:
- Replace grep -oP (GNU/PCRE) with POSIX sed for ROCm and CUDA version extraction in _print_run_env_table (portable in Alpine/BusyBox containers)
- Guard is_therock_tree() with Path.is_dir() so unknown/invalid host paths show "unknown" instead of "apt install" in the run-phase environment table
- Update validators.py to check docker_env_vars['ROCM_PATH'] (not MAD_ROCM_PATH)
- Update tests to match new direct-ROCM_PATH interface; add 7 new finalize tests
