### PR TITLE
docs: add Docker build-context tools entry to v2.1.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`examples/slurm-configs/minimal/slurm-multi-minimal.json`**: minimal reference config for the new launcher.
 
+- **Docker build context — shared `tools/` API access**: `docker build` now passes `--build-context tools=./tools`, making the `./tools` directory available as a named build context inside every Dockerfile. This allows Dockerfiles to `COPY --from=tools` shared helper scripts and APIs without duplicating them into each model's build context.
+
 ### Changed
 
 - **Early model discovery reuse in `BuildOrchestrator`**: The `DiscoverModels` result from the slurm_multi registry-gate check is now cached and reused for the actual build step, avoiding duplicate `get_models_json.py` execution and duplicate console output.

--- a/src/madengine/execution/docker_builder.py
+++ b/src/madengine/execution/docker_builder.py
@@ -179,6 +179,7 @@ class DockerBuilder:
 
         build_command = (
             f"docker build {use_cache_str} --network=host "
+            f"--build-context tools=./tools "
             f"-t {shlex.quote(docker_image)} --pull -f {shlex.quote(dockerfile)} "
             f"{build_args} {shlex.quote(docker_context)}"
         )


### PR DESCRIPTION
 ## Summary

  - Adds the missing `--build-context tools=./tools` entry to the v2.1.0 CHANGELOG section
  - The underlying code change (PR #131) already landed in `develop`; this fills the gap in the release notes

  ## Changes

  - `CHANGELOG.md`: one new bullet under `[2.1.0] Added` documenting that `docker build` now passes `--build-context tools=./tools`, making the `./tools` directory
  available as a named build context inside every Dockerfile so model Dockerfiles can `COPY --from=tools` shared helpers without duplication

  ## Test plan

  - [ ] Verify `CHANGELOG.md` renders correctly (no formatting issues around the new bullet)