### PR TITLE
changed tools_dir back to tools from scripts/common/tools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`tools/` build context conditionally included**: `docker build` now only passes `--build-context tools=./scripts/common/tools` when the `tools` directory actually exists, preventing build failures in environments where the directory is absent (e.g. clean checkouts before `madengine run` populates `scripts/common/`).
+- **`tools/` build context path corrected**: `docker build` now resolves the shared tools directory as `./tools` (project root) instead of `./scripts/common/tools`. The previous path was stale — `scripts/common/tools` is a temporary directory populated at runtime by `madengine run`, so it was absent during standalone `madengine build` invocations, silently omitting the `--build-context tools=…` flag and breaking Dockerfiles that rely on it via `COPY --from=tools`.
 
-- **SLURM env var escaping**: Switched from `shlex.quote()` to double-quote escaping for env var values in generated SBATCH wrapper scripts. `shlex.quote()` produced single-quoted strings that broke paths with spaces and special characters (e.g. directories with embedded variables); double-quoting is more portable for shell assignment in SLURM batch contexts.
-
-- **Hatch package artifacts include `scripts/`**: `pyproject.toml` now uses `[tool.hatch.build.artifacts]` to force-include the `scripts/` directory in the built wheel, ensuring pre/post scripts and tools bundled under `src/madengine/scripts/` are present in installed environments even though `.gitignore` excludes them from source tracking. Removes the previous `force-include` directive that caused `duplicate file` errors with newer hatchling versions.
+- **Hatch package artifacts include `scripts/`**: `pyproject.toml` now uses `[tool.hatch.build.artifacts]` to include the `scripts/` directory in the built wheel. The previous `force-include` directive caused `duplicate file` errors with newer hatchling versions (which are stricter about files already covered by the default source inclusion). Switching to `artifacts` bypasses `.gitignore` exclusion without risk of duplication. The `deployment/templates` force-include was also removed as it is already captured by the default wheel source scan.
 
 ## [2.1.0] - 2026-05-28
 

--- a/src/madengine/execution/docker_builder.py
+++ b/src/madengine/execution/docker_builder.py
@@ -179,7 +179,7 @@ class DockerBuilder:
         build_start_time = time.time()
 
         tools_build_context = ""
-        tools_dir = Path("scripts/common/tools")
+        tools_dir = Path("tools")
         if tools_dir.exists():
             tools_build_context = f"--build-context tools={tools_dir} "
 


### PR DESCRIPTION
## Motivation

Make tools/ directory accessible during docker build for shared API.

## Technical Details

Changing the build_context back from scripts/common/tools to tools/ directory as former one is cleaned by madengine. However difference from initial PR is that, it will check the existence of directory first and will assign build_context so that pytests test. 

## Test Plan

Run all 3 pytests (unit, integration and e2e)

## Test Result

[e2e.log](https://github.com/user-attachments/files/28483719/e2e.log)

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
[integration.log](https://github.com/user-attachments/files/28483720/integration.log)
[unit.log](https://github.com/user-attachments/files/28483721/unit.log)
