### PR TITLE
fix: remove redundant force-include that breaks newer hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,8 @@ dev = [
 ]
 
 [tool.hatch.build.targets.wheel]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/madengine/scripts" = "madengine/scripts"
+# Note: scripts directory is auto-included since it's under src/madengine/
+# Do NOT add force-include for it - causes duplicate file errors in newer hatchling
 
 [tool.hatch.version]
 source = "versioningit"


### PR DESCRIPTION
The scripts directory is already auto-included since it's under src/madengine/. The force-include was causing 'duplicate file' errors with newer hatchling versions that are stricter about this.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
