### PR TITLE
fix: remove redundant force-include that breaks newer hatchling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-06-02
+
+### Fixed
+
+- **`tools/` build context conditionally included**: `docker build` now only passes `--build-context tools=./scripts/common/tools` when the `tools` directory actually exists, preventing build failures in environments where the directory is absent (e.g. clean checkouts before `madengine run` populates `scripts/common/`).
+
+- **SLURM env var escaping**: Switched from `shlex.quote()` to double-quote escaping for env var values in generated SBATCH wrapper scripts. `shlex.quote()` produced single-quoted strings that broke paths with spaces and special characters (e.g. directories with embedded variables); double-quoting is more portable for shell assignment in SLURM batch contexts.
+
+- **Hatch package artifacts include `scripts/`**: `pyproject.toml` now uses `[tool.hatch.build.artifacts]` to force-include the `scripts/` directory in the built wheel, ensuring pre/post scripts and tools bundled under `src/madengine/scripts/` are present in installed environments even though `.gitignore` excludes them from source tracking. Removes the previous `force-include` directive that caused `duplicate file` errors with newer hatchling versions.
+
 ## [2.1.0] - 2026-05-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,11 @@ all = [
 ]
 
 [tool.hatch.build.targets.wheel]
-# Note: scripts directory is auto-included since it's under src/madengine/
-# Do NOT add force-include for it - causes duplicate file errors in newer hatchling
+# scripts/ is listed in .gitignore (to exclude external MAD project scripts/ dirs during dev).
+# artifacts bypasses VCS exclusion without risk of duplicate-file errors from force-include.
+artifacts = [
+  "src/madengine/scripts/**",
+]
 
 [tool.hatch.version]
 source = "versioningit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,8 @@ all = [
 [tool.hatch.build.targets.wheel]
 
 [tool.hatch.build.targets.wheel.force-include]
-"src/madengine/scripts" = "madengine/scripts"
-"src/madengine/deployment/templates" = "madengine/deployment/templates"
+# Note: scripts directory is auto-included since it's under src/madengine/
+# Do NOT add force-include for it - causes duplicate file errors in newer hatchling
 
 [tool.hatch.version]
 source = "versioningit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,6 @@ all = [
 ]
 
 [tool.hatch.build.targets.wheel]
-
-[tool.hatch.build.targets.wheel.force-include]
 # Note: scripts directory is auto-included since it's under src/madengine/
 # Do NOT add force-include for it - causes duplicate file errors in newer hatchling
 


### PR DESCRIPTION
The scripts directory is already auto-included since it's under src/madengine/. The force-include was causing 'duplicate file' errors with newer hatchling versions that are stricter about this.

