### PR TITLE
Guyen/develop build context folder change

### DIFF
--- a/src/madengine/execution/docker_builder.py
+++ b/src/madengine/execution/docker_builder.py
@@ -179,7 +179,7 @@ class DockerBuilder:
         build_start_time = time.time()
 
         tools_build_context = ""
-        tools_dir = Path("scripts/common/tools")
+        tools_dir = Path("tools")
         if tools_dir.exists():
             tools_build_context = f"--build-context tools={tools_dir} "
 

--- a/src/madengine/execution/docker_builder.py
+++ b/src/madengine/execution/docker_builder.py
@@ -179,9 +179,9 @@ class DockerBuilder:
         build_start_time = time.time()
 
         tools_build_context = ""
-        tools_dir = Path("tools")
-        if tools_dir.exists():
-            tools_build_context = f"--build-context tools={tools_dir} "
+        docker_api_dir = Path("docker/common")
+        if docker_api_dir.exists():
+            tools_build_context = f"--build-context tools={docker_api_dir} "
 
         build_command = (
             f"docker build {use_cache_str} --network=host "


### PR DESCRIPTION
## Motivation

Moving tools_dir from tools/ to docker/common/ and also change variable name accordingly to docker_api_dir. 

## Technical Details

Moving tools_dir from tools/ to docker/common/ and also change variable name accordingly to docker_api_dir. 

## Test Plan

Run the docker build and run benchmark utilizing and binding the file from new location. 
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
