### PR TITLE
fix(run): correct --skip-model-run behaviour; container starts before skip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,4 @@ rocm_trace_lite_output/
 slurm_results/
 MagicMock/
 .madengine_session_start
-run_directory/.worktrees/
+run_directory/

--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,4 @@ rocm_trace_lite_output/
 slurm_results/
 MagicMock/
 .madengine_session_start
-run_directory/
+run_directory/.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`pytest` lower bound pinned to `>=7.0`**: Aligns the dependency pin with `minversion = "7.0"` already declared in `[tool.pytest.ini_options]`, preventing accidental resolution of older pytest versions that cannot run this project's tests.
 
+### Changed
+
+- **`--skip-model-run` now matches v1 semantics**: The flag previously short-circuited the entire run before any container started, and only took effect when a build ran in the same invocation (otherwise it was ignored with a warning). It now starts the container and runs `pre_scripts` and `post_scripts` as normal, skipping **only** the model script invocation — regardless of whether a build ran. The skip decision was moved out of `RunOrchestrator` and into `ContainerRunner`, so it applies uniformly to build+run and manifest-only (`--manifest-file`) invocations.
+
+- **`--skip-model-run` runs report `SKIPPED`, not `FAILURE`**: A skipped model is now aggregated as a successful run with status `SKIPPED`, and the overall workflow exits `0`. Previously a skipped run could surface as a failure.
+
+### Added
+
+- **`--skip-model-run --keep-alive` for live container debugging**: Combining the two flags leaves a fully-set-up container alive after the skipped run, ready for manual exec (`docker exec -it <container> bash`). When `--keep-alive` is set, the run prints the exact `cd <model_dir> && <script> <args>` command to invoke the model by hand; otherwise it hints to re-run with `--keep-alive`.
+
+- **Warning for local-only flags on distributed targets**: Passing `--skip-model-run`, `--keep-alive`, or `--keep-model-dir` with a SLURM or Kubernetes target now prints a yellow warning that these local Docker-only flags are ignored.
+
 ### Fixed
 
 - **`tools/` build context path corrected**: `docker build` now resolves the shared tools directory as `./tools` (project root) instead of `./scripts/common/tools`. The previous path was stale — `scripts/common/tools` is a temporary directory populated at runtime by `madengine run`, so it was absent during standalone `madengine build` invocations, silently omitting the `--build-context tools=…` flag and breaking Dockerfiles that rely on it via `COPY --from=tools`.
@@ -261,12 +273,6 @@ madengine v2.0 is a **complete rewrite** with a unified CLI architecture, replac
 - **Use case**: CI/CD pipelines that only need image validation
 - **Full workflow**: Discover → Build → Skip execution, but validate configuration
 - **Exit code preservation**: Returns appropriate exit codes for build failures
-
-#### Fix --skip-model-run to match v1 behaviour
-- **Container now starts**: `--skip-model-run` previously short-circuited before any container started; now the container starts, `pre_scripts` run, and only the model script invocation is skipped
-- **Live container debugging**: `--skip-model-run --keep-alive` leaves a fully-set-up container alive for manual exec (`docker exec -it <container> bash`)
-- **Correct exit status**: Skipped runs are now reported as `SKIPPED` (not `FAILURE`); overall exit code is `0`
-- **Distributed warning**: Passing `--skip-model-run`, `--keep-alive`, or `--keep-model-dir` with a SLURM/K8s target now emits a yellow warning (these flags are local Docker-only)
 
 #### ROCprofv3 Profiling Suite (ROCm 7.0+)
 - **8 pre-configured profiles**: compute, memory, communication, full, lightweight, perfetto, api_overhead, pc_sampling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,12 @@ madengine v2.0 is a **complete rewrite** with a unified CLI architecture, replac
 - **Full workflow**: Discover → Build → Skip execution, but validate configuration
 - **Exit code preservation**: Returns appropriate exit codes for build failures
 
+#### Fix --skip-model-run to match v1 behaviour
+- **Container now starts**: `--skip-model-run` previously short-circuited before any container started; now the container starts, `pre_scripts` run, and only the model script invocation is skipped
+- **Live container debugging**: `--skip-model-run --keep-alive` leaves a fully-set-up container alive for manual exec (`docker exec -it <container> bash`)
+- **Correct exit status**: Skipped runs are now reported as `SKIPPED` (not `FAILURE`); overall exit code is `0`
+- **Distributed warning**: Passing `--skip-model-run`, `--keep-alive`, or `--keep-model-dir` with a SLURM/K8s target now emits a yellow warning (these flags are local Docker-only)
+
 #### ROCprofv3 Profiling Suite (ROCm 7.0+)
 - **8 pre-configured profiles**: compute, memory, communication, full, lightweight, perfetto, api_overhead, pc_sampling
 - **Hardware counter definitions**: 4 counter files for targeted profiling scenarios
@@ -615,8 +621,8 @@ black src/ tests/ && isort src/ tests/
 # Run pre-commit hooks manually
 pre-commit run --all-files
 
-# Build without running (CI/CD)
-madengine run --tags model --skip-model-run
+# Skip model script (container starts, pre_scripts run); leave live container for debugging
+madengine run --tags model --skip-model-run --keep-alive
 
 # Debug with verbose output
 madengine run --tags model --verbose --live-output

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ After a local Docker run, madengine can scan the captured **run log** for common
 ### Build & Deployment
 
 - **Separate build and run phases** for distributed deployments
-- **Build without executing:** `madengine run --tags … --skip-model-run` skips container execution **after a build in that same invocation** (ignored when using an existing `--manifest-file`). See [Usage — Skip model run after build](docs/usage.md#skip-model-run-after-build).
+- **Skip model script:** `madengine run --tags … --skip-model-run` starts the container and runs `pre_scripts`, but skips the model script. Combine with `--keep-alive` for a live container ready for manual exec. Ignored with a warning on SLURM/K8s. See [Usage — Skip model run after build](docs/usage.md#skip-model-run-after-build).
 - **Use registries** for multi-node execution (K8s/SLURM)
 - **Use batch build mode** for CI/CD to optimize build times
 - **Specify `--target-archs`** when building for multiple GPU architectures

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -227,7 +227,7 @@ madengine run [OPTIONS]
 | `--additional-context` | `-c` | TEXT | `"{}"` | Additional context as JSON string |
 | `--additional-context-file` | `-f` | TEXT | `None` | File containing additional context JSON |
 | `--keep-alive` | | FLAG | `False` | Keep Docker containers alive after run (local Docker only; ignored with a warning on SLURM/K8s) |
-| `--keep-model-dir` | | FLAG | `False` | Keep model directory after run |
+| `--keep-model-dir` | | FLAG | `False` | Keep model directory after run (local Docker only; ignored with a warning on SLURM/K8s) |
 | `--clean-docker-cache` | | FLAG | `False` | Rebuild images without using cache (full workflow) |
 | `--skip-model-run` | | FLAG | `False` | Skip the model script inside each container. The container still starts and `pre_scripts` still run; only the model script invocation is skipped (status reported as `SKIPPED`, exit code `0`). Combine with `--keep-alive` to leave a live container for manual exec. Ignored with a warning on SLURM/K8s targets. See [Usage — Skip model run](usage.md#skip-model-run-after-build). |
 | `--manifest-output` | | TEXT | `build_manifest.json` | Output file for build manifest (full workflow) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -226,10 +226,10 @@ madengine run [OPTIONS]
 | `--timeout` | | INT | `-1` | Timeout in seconds (-1=default 7200s, 0=no timeout) |
 | `--additional-context` | `-c` | TEXT | `"{}"` | Additional context as JSON string |
 | `--additional-context-file` | `-f` | TEXT | `None` | File containing additional context JSON |
-| `--keep-alive` | | FLAG | `False` | Keep Docker containers alive after run |
+| `--keep-alive` | | FLAG | `False` | Keep Docker containers alive after run (local Docker only; ignored with a warning on SLURM/K8s) |
 | `--keep-model-dir` | | FLAG | `False` | Keep model directory after run |
 | `--clean-docker-cache` | | FLAG | `False` | Rebuild images without using cache (full workflow) |
-| `--skip-model-run` | | FLAG | `False` | After a **build in this invocation**, skip executing models (manifest/images still produced). **Ignored** when using `--manifest-file` with an existing manifest (run-only), or when no build ran in this invocation. See [Usage — Skip model run](usage.md#skip-model-run-after-build). |
+| `--skip-model-run` | | FLAG | `False` | Skip the model script inside each container. The container still starts and `pre_scripts` still run; only the model script invocation is skipped (status reported as `SKIPPED`, exit code `0`). Combine with `--keep-alive` to leave a live container for manual exec. Ignored with a warning on SLURM/K8s targets. See [Usage — Skip model run](usage.md#skip-model-run-after-build). |
 | `--manifest-output` | | TEXT | `build_manifest.json` | Output file for build manifest (full workflow) |
 | `--summary-output` | `-s` | TEXT | `None` | Output file for summary JSON |
 | `--live-output` | `-l` | FLAG | `False` | Print output in real-time |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -283,15 +283,25 @@ madengine build --batch-manifest batch.json \
 
 ### Skip model run after build
 
-When `madengine run` **builds** in the same invocation (no pre-existing `--manifest-file`), you can pass **`--skip-model-run`** to produce images and `build_manifest.json` **without** running model containers.
+Pass **`--skip-model-run`** to start containers and run `pre_scripts`, but skip executing the model script itself.
 
-- **Ignored** when `--manifest-file` points at an existing manifest (execution-only mode): use plain `madengine run --manifest-file ...` to run later.
-- **Ignored** with a warning if this invocation did not perform a build (for example a manifest was already present and no rebuild occurred).
+- The Docker container **is started** and `pre_scripts` run normally.
+- Only the model script invocation is skipped; `post_scripts` and container cleanup still run.
+- Exit status is `SKIPPED` (not `FAILURE`) — the overall run exits `0`.
+- Combine with **`--keep-alive`** to leave a fully-set-up, live container for manual inspection or debugging.
+- Has **no effect** on distributed (SLURM/K8s) targets — a warning is printed if used with them.
 
 ```bash
+# Skip the model script; container starts and pre_scripts run
 madengine run --tags model \
   --additional-context '{"gpu_vendor": "AMD", "guest_os": "UBUNTU"}' \
   --skip-model-run
+
+# Leave a live container ready for manual exec
+madengine run --tags model \
+  --additional-context '{"gpu_vendor": "AMD", "guest_os": "UBUNTU"}' \
+  --skip-model-run --keep-alive
+# Then: docker exec -it <container> bash
 ```
 
 See [CLI Reference — `run`](cli-reference.md#run---execute-models) and `madengine run --help`.
@@ -425,8 +435,12 @@ madengine run --tags model --timeout 0
 ### Debugging
 
 ```bash
-# Keep containers alive
+# Keep container alive after run (local Docker only)
 madengine run --tags model --keep-alive
+
+# Skip model script and leave a live container ready for manual exec
+madengine run --tags model --skip-model-run --keep-alive
+# Then inspect: docker exec -it <container> bash
 
 # Verbose output
 madengine run --tags model --verbose --live-output
@@ -714,8 +728,11 @@ madengine run --tags model1 --tags model2,model3
 # Full verbose output with real-time logs
 madengine run --tags model --verbose --live-output
 
-# Keep container alive for inspection
+# Keep container alive for inspection (local Docker only)
 madengine run --tags model --keep-alive
+
+# Skip model script and leave live container for manual exec
+madengine run --tags model --skip-model-run --keep-alive
 
 # Check what will be discovered
 madengine discover --tags model --verbose

--- a/src/madengine/cli/commands/run.py
+++ b/src/madengine/cli/commands/run.py
@@ -406,10 +406,6 @@ def run(
             save_summary_with_feedback(workflow_summary, summary_output, "Workflow")
 
             if workflow_summary["overall_success"]:
-                if execution_summary.get("skipped_model_run"):
-                    console.print(
-                        "[cyan]Model run was skipped (--skip-model-run); build completed.[/cyan]"
-                    )
                 console.print(
                     "🎉 [bold green]Complete workflow finished successfully![/bold green]"
                 )

--- a/src/madengine/cli/commands/run.py
+++ b/src/madengine/cli/commands/run.py
@@ -202,12 +202,6 @@ def run(
         manifest_exists = manifest_file and os.path.exists(manifest_file)
 
         if manifest_exists:
-            if skip_model_run:
-                console.print(
-                    "[yellow]⚠️  --skip-model-run applies only after a build in this invocation; "
-                    "using an existing manifest. Ignoring --skip-model-run.[/yellow]"
-                )
-
             console.print(
                 Panel(
                     f"🚀 [bold cyan]Running Models (Execution Only)[/bold cyan]\n"

--- a/src/madengine/cli/commands/run.py
+++ b/src/madengine/cli/commands/run.py
@@ -99,7 +99,11 @@ def run(
         bool,
         typer.Option(
             "--skip-model-run",
-            help="After a build in this invocation, skip executing models (ignored when using an existing manifest).",
+            help=(
+                "Skip running the model script inside the container. "
+                "The container is still started and pre_scripts still run. "
+                "Use with --keep-alive to get a live container set up and ready for manual exec."
+            ),
         ),
     ] = False,
     manifest_output: Annotated[

--- a/src/madengine/core/docker.py
+++ b/src/madengine/core/docker.py
@@ -142,13 +142,13 @@ class Docker:
     def __del__(self):
         """Destructor of the Docker class."""
         # stop and remove docker container, if not keep_alive and docker sha exists, else print docker sha.
-        if not self.keep_alive and self.docker_sha:
+        if not getattr(self, "keep_alive", False) and getattr(self, "docker_sha", None):
             self.console.sh("docker stop -t 1 " + self.docker_sha)
             self.console.sh("docker rm -f " + self.docker_sha)
             return
 
         # print docker sha
-        if self.docker_sha:
+        if getattr(self, "docker_sha", None):
             print("==========================================")
             print("Keeping docker alive, sha :", self.docker_sha)
             print(

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -1041,6 +1041,7 @@ class ContainerRunner:
         build_info: typing.Dict = None,
         keep_alive: bool = False,
         keep_model_dir: bool = False,
+        skip_model_run: bool = False,
         timeout: int = 7200,
         tools_json_file: str = "scripts/common/tools.json",
         phase_suffix: str = "",
@@ -1054,6 +1055,7 @@ class ContainerRunner:
             build_info: Optional build information from manifest
             keep_alive: Whether to keep container alive after execution
             keep_model_dir: Whether to keep model directory after execution
+            skip_model_run: Whether to skip the model script invocation
             timeout: Execution timeout in seconds
             tools_json_file: Path to tools configuration file
             phase_suffix: Suffix for log file name (e.g., ".run" or "")
@@ -1542,22 +1544,25 @@ class ContainerRunner:
                         # Set permissions
                         model_docker.sh(f"chmod -R a+rw {model_dir}")
 
-                        # Run the model
+                        # Run the model (or skip, leaving container alive for manual exec)
                         test_start_time = time.time()
-                        self.rich_console.print("[bold blue]Running model...[/bold blue]")
-
-                        model_args = self.context.ctx.get(
-                            "model_args", model_info["args"]
-                        )
-                        # Use the container timeout (default 7200s) for script execution
-                        # to prevent indefinite hangs
-                        model_output = model_docker.sh(
-                            f"cd {model_dir} && {script_name} {model_args}",
-                            timeout=timeout,
-                        )
-                        # When live_output is True, Console.sh() already streamed the output; avoid duplicate print.
-                        if not self.live_output:
-                            print(model_output)
+                        model_args = self.context.ctx.get("model_args", model_info["args"])
+                        if skip_model_run:
+                            self.rich_console.print(
+                                "[bold cyan]Skipping model run (--skip-model-run).[/bold cyan]"
+                            )
+                            print(f"To run model: cd {model_dir} && {script_name} {model_args}")
+                        else:
+                            self.rich_console.print("[bold blue]Running model...[/bold blue]")
+                            # Use the container timeout (default 7200s) for script execution
+                            # to prevent indefinite hangs
+                            model_output = model_docker.sh(
+                                f"cd {model_dir} && {script_name} {model_args}",
+                                timeout=timeout,
+                            )
+                            # When live_output is True, Console.sh() already streamed the output; avoid duplicate print.
+                            if not self.live_output:
+                                print(model_output)
 
                         run_results["test_duration"] = time.time() - test_start_time
                         print(f"Test Duration: {run_results['test_duration']} seconds")
@@ -2046,6 +2051,7 @@ class ContainerRunner:
         timeout: int = 7200,
         keep_alive: bool = False,
         keep_model_dir: bool = False,
+        skip_model_run: bool = False,
         phase_suffix: str = "",
     ) -> typing.Dict:
         """Run all models from a build manifest file.
@@ -2058,6 +2064,7 @@ class ContainerRunner:
             timeout: Execution timeout per model in seconds
             keep_alive: Whether to keep containers alive after execution
             keep_model_dir: Whether to keep model directory after execution
+            skip_model_run: Whether to skip the model script invocation
             phase_suffix: Suffix for log files (e.g., ".run")
 
         Returns:
@@ -2144,6 +2151,7 @@ class ContainerRunner:
                     build_info=build_info,
                     keep_alive=keep_alive,
                     keep_model_dir=keep_model_dir,
+                    skip_model_run=skip_model_run,
                     timeout=timeout,
                     phase_suffix=phase_suffix,
                 )

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -2172,6 +2172,17 @@ class ContainerRunner:
                         "performance": run_results.get("performance"),
                         "duration": run_results.get("test_duration"),
                     })
+                elif status == "SKIPPED":
+                    successful_runs.append({
+                        "model": model_info["name"],
+                        "image": run_image,
+                        "status": "SKIPPED",
+                        "performance": None,
+                        "duration": run_results.get("test_duration"),
+                    })
+                    self.rich_console.print(
+                        f"[cyan]⏭️  Skipped model run for {model_info['name']}[/cyan]"
+                    )
                 else:
                     # Status is FAILURE - track as failed
                     failed_runs.append({

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -1551,7 +1551,14 @@ class ContainerRunner:
                             self.rich_console.print(
                                 "[bold cyan]Skipping model run (--skip-model-run).[/bold cyan]"
                             )
-                            print(f"To run model: cd {model_dir} && {script_name} {model_args}")
+                            if keep_alive:
+                                self.rich_console.print(
+                                    f"[dim]To run model manually:[/dim] cd {model_dir} && {script_name} {model_args}"
+                                )
+                            else:
+                                self.rich_console.print(
+                                    "[dim]Tip: re-run with --keep-alive to keep the container and model dir for manual exec.[/dim]"
+                                )
                         else:
                             self.rich_console.print("[bold blue]Running model...[/bold blue]")
                             # Use the container timeout (default 7200s) for script execution

--- a/src/madengine/execution/container_runner.py
+++ b/src/madengine/execution/container_runner.py
@@ -1577,395 +1577,401 @@ class ContainerRunner:
                                 pre_encapsulate_post_scripts["post_scripts"],
                             )
 
-                        # When model writes performance to a file in run_directory, copy to cwd
-                        # so the host can read it (e.g. bind-mounted workspace) before extraction.
-                        multiple_results_file = (model_info.get("multiple_results") or "").strip()
-                        if multiple_results_file:
-                            try:
-                                model_docker.sh(
-                                    _cp_model_dir_file_to_cwd_cmd(
-                                        model_dir, multiple_results_file
-                                    )
-                                )
-                            except Exception:
-                                pass
-
-                        # Extract performance metrics from logs
-                        # Look for performance data in the log output similar to original run_models.py
-                        try:
-                            # Check if multiple results file is specified in model_info
-                            multiple_results = model_info.get("multiple_results", None)
-                            if multiple_results:
-                                multiple_results = multiple_results.strip()
-
-                            if multiple_results:
-                                resolved_path = _resolve_multiple_results_path(
-                                    multiple_results, model_dir
-                                )
-                                if not resolved_path:
-                                    self.rich_console.print(
-                                        f"[yellow]Warning: Could not find multiple results file "
-                                        f"(tried cwd and {model_dir}/): {multiple_results}[/yellow]"
-                                    )
-                                    run_results["performance"] = None
-                                else:
-                                    run_results["performance"] = resolved_path
-                                    # Validate multiple results file format using proper CSV parsing
-                                    try:
-                                        import csv
-                                        with open(resolved_path, "r") as f:
-                                            csv_reader = csv.DictReader(f)
-
-                                            # Strip whitespace from fieldnames to handle headers like "model, performance, metric"
-                                            csv_reader.fieldnames = [f.strip() for f in csv_reader.fieldnames]
-
-                                            # Check if 'performance' column exists
-                                            if 'performance' not in csv_reader.fieldnames:
-                                                print("Error: 'performance' column not found in multiple results file.")
-                                                run_results["performance"] = None
-                                            else:
-                                                # Check if at least one row has a non-empty performance value
-                                                has_valid_perf = False
-                                                for row in csv_reader:
-                                                    if row.get('performance', '').strip():
-                                                        has_valid_perf = True
-                                                        break
-                                                
-                                                if not has_valid_perf:
-                                                    run_results["performance"] = None
-                                                    print("Error: Performance metric is empty in all rows of multiple results file.")
-                                    except Exception as e:
-                                        self.rich_console.print(
-                                            f"[yellow]Warning: Could not validate multiple results file: {e}[/yellow]"
-                                        )
-                                        run_results["performance"] = None
-                            else:
-                                # Match the actual output format: "performance: 14164 samples_per_second"
-                                # Simple pattern to capture number and metric unit
-
-                                # Extract from log file
-                                try:
-                                    # Note: re and os are already imported at module level (lines 10, 15)
-                                    
-                                    # Verify log file exists and is readable
-                                    if not os.path.exists(log_file_path):
-                                        print(f"Warning: Log file not found: {log_file_path}")
-                                        run_results["performance"] = None
-                                        run_results["metric"] = None
-                                    else:
-                                        # Read the log file once (avoids rocprofv3 crash from shell pipelines)
-                                        # This approach matches the Kubernetes implementation pattern
-                                        with open(log_file_path, 'r', encoding='utf-8', errors='ignore') as f:
-                                            log_content = f.read()
-                                        
-                                        # Try multiple patterns to match different log formats
-                                        
-                                        # Pattern 1: "performance: <value>[<unit>][,] <metric>"
-                                        # See PERFORMANCE_LOG_PATTERN in deployment.base for accepted formats.
-                                        match = re.search(PERFORMANCE_LOG_PATTERN, log_content)
-                                        
-                                        if match:
-                                            run_results["performance"] = match.group(1).strip()
-                                            run_results["metric"] = match.group(2).strip()
-                                            print(f"✓ Extracted performance: {run_results['performance']} {run_results['metric']}")
-                                        else:
-                                            # Pattern 2: HuggingFace format - "'train_samples_per_second': 4.23" or "train_samples_per_second = 4.23"
-                                            # This matches the actual output from HuggingFace Trainer
-                                            hf_pattern = r'train_samples_per_second[\'"\s:=]+([0-9][0-9.eE+-]*)'
-                                            hf_match = re.search(hf_pattern, log_content)
-                                            
-                                            if hf_match:
-                                                run_results["performance"] = hf_match.group(1).strip()
-                                                run_results["metric"] = "samples_per_second"
-                                                print(f"✓ Extracted performance (HuggingFace format): {run_results['performance']} {run_results['metric']}")
-                                            else:
-                                                # No performance metrics found
-                                                print("Warning: Performance metric not found in expected format 'performance: NUMBER METRIC' or 'train_samples_per_second'")
-                                                run_results["performance"] = None
-                                                run_results["metric"] = None
-                                            
-                                except Exception as e:
-                                    print(f"Warning: Error extracting performance metrics: {e}")
-                                    run_results["performance"] = None
-                                    run_results["metric"] = None
-                                    # Performance extraction is optional - don't fail the entire run
-                        except Exception as e:
-                            print(
-                                f"Warning: Could not extract performance metrics: {e}"
-                            )
-
-                        # Set status based on performance and error patterns
-                        # First check for obvious failure patterns in the logs
-                        try:
-                            scan_logs, error_patterns, extra_benign = (
-                                resolve_log_error_scan_config(
-                                    model_info, self.additional_context
-                                )
-                            )
-
-                            has_errors = False
-                            if (
-                                scan_logs
-                                and log_file_path
-                                and os.path.exists(log_file_path)
-                            ):
-                                try:
-                                    # Benign: literal substrings (incl. user extra_benign) vs regex (ROCProf lines).
-                                    benign_substrings = [
-                                        "Failed to establish connection to the metrics exporter agent",
-                                        "RpcError: Running out of retries to initialize the metrics agent",
-                                        "Metrics will not be exported",
-                                        "FutureWarning",
-                                        "Opened result file:",
-                                        "SQLite3 generation ::",
-                                        "rocpd_op:",
-                                        "rpd_tracer:",
-                                    ]
-                                    benign_substrings.extend(extra_benign)
-                                    benign_regexes = [
-                                        # ROCProf/glog: E/W prefixes are log levels, not app errors
-                                        r"^E[0-9]{8}.*generateRocpd\.cpp",
-                                        r"^W[0-9]{8}.*simple_timer\.cpp",
-                                        r"^W[0-9]{8}.*generateRocpd\.cpp",
-                                        r"^E[0-9]{8}.*tool\.cpp",
-                                        r"\[rocprofv3\]",
-                                    ]
-
-                                    # Scan in Python (no shell; literals vs regex benign rules are explicit).
-                                    with open(
-                                        log_file_path,
-                                        "r",
-                                        encoding="utf-8",
-                                        errors="ignore",
-                                    ) as _lf:
-                                        log_scan_text = _lf.read()
-
-                                    for pattern in error_patterns:
-                                        if log_text_has_error_pattern(
-                                            log_scan_text,
-                                            pattern,
-                                            benign_substrings,
-                                            benign_regexes,
-                                        ):
-                                            has_errors = True
-                                            print(
-                                                f"Found error pattern '{pattern}' in logs"
-                                            )
-                                            break
-                                except Exception:
-                                    pass  # Error checking is optional
-                            elif not scan_logs:
-                                self.rich_console.print(
-                                    "[dim]ℹ️  Log error pattern scan disabled "
-                                    "(log_error_pattern_scan).[/dim]"
-                                )
-
-                            # Status logic: Must have performance AND no errors to be considered success
-                            # Exception: Worker nodes in multi-node training (MAD_COLLECT_METRICS=false)
-                            # are not expected to report global performance metrics
-                            performance_value = run_results.get("performance")
-                            has_performance = (
-                                performance_value
-                                and performance_value.strip()
-                                and performance_value.strip() != "N/A"
-                            )
-                            
-                            # Check if this is a worker node (not collecting metrics)
-                            is_worker_node = os.environ.get("MAD_COLLECT_METRICS", "true").lower() == "false"
-
-                            if has_errors:
-                                run_results["status"] = "FAILURE"
-                                self.rich_console.print(
-                                    f"[red]Status: FAILURE (error patterns detected in logs)[/red]"
-                                )
-                            elif has_performance:
-                                run_results["status"] = "SUCCESS"
-                                self.rich_console.print(
-                                    f"[green]Status: SUCCESS (performance metrics found, no errors)[/green]"
-                                )
-                            elif is_worker_node:
-                                # Worker nodes don't report global performance metrics - this is expected
-                                run_results["status"] = "SUCCESS"
-                                self.rich_console.print(
-                                    f"[green]Status: SUCCESS (worker node, no errors detected)[/green]"
-                                )
-                            else:
-                                run_results["status"] = "FAILURE"
-                                self.rich_console.print(f"[red]Status: FAILURE (no performance metrics)[/red]")
-
-                        except Exception as e:
-                            self.rich_console.print(f"[yellow]Warning: Error in status determination: {e}[/yellow]")
-                            # Fallback to simple performance check
-                            # Worker nodes don't need performance metrics
-                            is_worker_node = os.environ.get("MAD_COLLECT_METRICS", "true").lower() == "false"
-                            run_results["status"] = (
-                                "SUCCESS"
-                                if run_results.get("performance") or is_worker_node
-                                else "FAILURE"
-                            )
-
-                        print(
-                            f"{model_info['name']} performance is {run_results.get('performance', 'N/A')} {run_results.get('metric', '')}"
-                        )
-
-                        # =============================================================================
-                        # Multi-Node Performance Collection (Master Node Only)
-                        # =============================================================================
-                        # For distributed training, only master node should collect metrics
-                        # Check skip_perf_collection flag from additional_context
-                        skip_perf = self.additional_context.get("skip_perf_collection", False)
-                        
-                        if skip_perf:
+                        if skip_model_run:
+                            run_results["status"] = "SKIPPED"
                             self.rich_console.print(
-                                "[cyan]ℹ️  Worker node: Skipping performance metric collection "
-                                "(master node will collect results)[/cyan]"
+                                "[bold cyan]Status: SKIPPED (--skip-model-run)[/bold cyan]"
                             )
                         else:
-                            # Generate performance results and update perf.csv
-                            self.ensure_perf_csv_exists()
+                            # When model writes performance to a file in run_directory, copy to cwd
+                            # so the host can read it (e.g. bind-mounted workspace) before extraction.
+                            multiple_results_file = (model_info.get("multiple_results") or "").strip()
+                            if multiple_results_file:
+                                try:
+                                    model_docker.sh(
+                                        _cp_model_dir_file_to_cwd_cmd(
+                                            model_dir, multiple_results_file
+                                        )
+                                    )
+                                except Exception:
+                                    pass
+
+                            # Extract performance metrics from logs
+                            # Look for performance data in the log output similar to original run_models.py
                             try:
-                                # Create run details dictionary for CSV generation
-                                run_details_dict = self.create_run_details_dict(
-                                    model_info, build_info, run_results
-                                )
-
-                                # Handle multiple results if specified
+                                # Check if multiple results file is specified in model_info
                                 multiple_results = model_info.get("multiple_results", None)
-                                resolved_multiple_results = (
-                                    _resolve_multiple_results_path(multiple_results, model_dir)
-                                    if multiple_results
-                                    else None
-                                )
-                                if (
-                                    resolved_multiple_results
-                                    and run_results.get("status") == "SUCCESS"
-                                ):
-                                    # Generate common info JSON for multiple results
-                                    common_info = run_details_dict.copy()
-                                    # Remove model-specific fields for common info
-                                    for key in ["model", "performance", "metric", "status"]:
-                                        common_info.pop(key, None)
+                                if multiple_results:
+                                    multiple_results = multiple_results.strip()
 
-                                    with open("common_info.json", "w") as f:
-                                        json.dump(common_info, f)
-
-                                    # Update perf.csv with multiple results
-                                    update_perf_csv(
-                                        multiple_results=resolved_multiple_results,
-                                        perf_csv=self.perf_csv_path,
-                                        model_name=run_details_dict["model"],
-                                        common_info="common_info.json",
+                                if multiple_results:
+                                    resolved_path = _resolve_multiple_results_path(
+                                        multiple_results, model_dir
                                     )
-                                    print(
-                                        f"Updated perf.csv with multiple results for {model_info['name']}"
-                                    )
-
-                                    # Update perf_super.json with multiple results
-                                    try:
-                                        scripts_path = model_info.get("scripts", "")
-                                        scripts_base_dir = scripts_base_dir_from(scripts_path)
-                                        
-                                        # Reuse common_info.json for super files (no need for duplicate)
-                                        num_entries = update_perf_super_json(
-                                            multiple_results=resolved_multiple_results,
-                                            perf_super_json="perf_super.json",
-                                            model_name=run_details_dict["model"],
-                                            common_info="common_info.json",
-                                            scripts_base_dir=scripts_base_dir,
+                                    if not resolved_path:
+                                        self.rich_console.print(
+                                            f"[yellow]Warning: Could not find multiple results file "
+                                            f"(tried cwd and {model_dir}/): {multiple_results}[/yellow]"
                                         )
-                                        
-                                        # Generate CSV and JSON files from perf_super.json
-                                        update_perf_super_csv(
-                                            perf_super_json="perf_super.json",
-                                            perf_super_csv="perf_super.csv",
-                                            num_entries=num_entries
-                                        )
-                                    except Exception as e:
-                                        print(f"⚠️  Warning: Could not update perf_super files: {e}")
-                                else:
-                                    # Generate single result JSON
-                                    with open("perf_entry.json", "w") as f:
-                                        json.dump(run_details_dict, f)
-
-                                    # Update perf.csv with single result
-                                    if run_results.get("status") == "SUCCESS":
-                                        update_perf_csv(
-                                            single_result="perf_entry.json",
-                                            perf_csv=self.perf_csv_path,
-                                        )
+                                        run_results["performance"] = None
                                     else:
-                                        update_perf_csv(
-                                            exception_result="perf_entry.json",
-                                            perf_csv=self.perf_csv_path,
-                                        )
-                                    print(
-                                        f"Updated perf.csv with result for {model_info['name']}"
+                                        run_results["performance"] = resolved_path
+                                        # Validate multiple results file format using proper CSV parsing
+                                        try:
+                                            import csv
+                                            with open(resolved_path, "r") as f:
+                                                csv_reader = csv.DictReader(f)
+
+                                                # Strip whitespace from fieldnames to handle headers like "model, performance, metric"
+                                                csv_reader.fieldnames = [f.strip() for f in csv_reader.fieldnames]
+
+                                                # Check if 'performance' column exists
+                                                if 'performance' not in csv_reader.fieldnames:
+                                                    print("Error: 'performance' column not found in multiple results file.")
+                                                    run_results["performance"] = None
+                                                else:
+                                                    # Check if at least one row has a non-empty performance value
+                                                    has_valid_perf = False
+                                                    for row in csv_reader:
+                                                        if row.get('performance', '').strip():
+                                                            has_valid_perf = True
+                                                            break
+
+                                                    if not has_valid_perf:
+                                                        run_results["performance"] = None
+                                                        print("Error: Performance metric is empty in all rows of multiple results file.")
+                                        except Exception as e:
+                                            self.rich_console.print(
+                                                f"[yellow]Warning: Could not validate multiple results file: {e}[/yellow]"
+                                            )
+                                            run_results["performance"] = None
+                                else:
+                                    # Match the actual output format: "performance: 14164 samples_per_second"
+                                    # Simple pattern to capture number and metric unit
+
+                                    # Extract from log file
+                                    try:
+                                        # Note: re and os are already imported at module level (lines 10, 15)
+
+                                        # Verify log file exists and is readable
+                                        if not os.path.exists(log_file_path):
+                                            print(f"Warning: Log file not found: {log_file_path}")
+                                            run_results["performance"] = None
+                                            run_results["metric"] = None
+                                        else:
+                                            # Read the log file once (avoids rocprofv3 crash from shell pipelines)
+                                            # This approach matches the Kubernetes implementation pattern
+                                            with open(log_file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                                                log_content = f.read()
+
+                                            # Try multiple patterns to match different log formats
+
+                                            # Pattern 1: "performance: <value>[<unit>][,] <metric>"
+                                            # See PERFORMANCE_LOG_PATTERN in deployment.base for accepted formats.
+                                            match = re.search(PERFORMANCE_LOG_PATTERN, log_content)
+
+                                            if match:
+                                                run_results["performance"] = match.group(1).strip()
+                                                run_results["metric"] = match.group(2).strip()
+                                                print(f"✓ Extracted performance: {run_results['performance']} {run_results['metric']}")
+                                            else:
+                                                # Pattern 2: HuggingFace format - "'train_samples_per_second': 4.23" or "train_samples_per_second = 4.23"
+                                                # This matches the actual output from HuggingFace Trainer
+                                                hf_pattern = r'train_samples_per_second[\'"\s:=]+([0-9][0-9.eE+-]*)'
+                                                hf_match = re.search(hf_pattern, log_content)
+
+                                                if hf_match:
+                                                    run_results["performance"] = hf_match.group(1).strip()
+                                                    run_results["metric"] = "samples_per_second"
+                                                    print(f"✓ Extracted performance (HuggingFace format): {run_results['performance']} {run_results['metric']}")
+                                                else:
+                                                    # No performance metrics found
+                                                    print("Warning: Performance metric not found in expected format 'performance: NUMBER METRIC' or 'train_samples_per_second'")
+                                                    run_results["performance"] = None
+                                                    run_results["metric"] = None
+
+                                    except Exception as e:
+                                        print(f"Warning: Error extracting performance metrics: {e}")
+                                        run_results["performance"] = None
+                                        run_results["metric"] = None
+                                        # Performance extraction is optional - don't fail the entire run
+                            except Exception as e:
+                                print(
+                                    f"Warning: Could not extract performance metrics: {e}"
+                                )
+
+                            # Set status based on performance and error patterns
+                            # First check for obvious failure patterns in the logs
+                            try:
+                                scan_logs, error_patterns, extra_benign = (
+                                    resolve_log_error_scan_config(
+                                        model_info, self.additional_context
+                                    )
+                                )
+
+                                has_errors = False
+                                if (
+                                    scan_logs
+                                    and log_file_path
+                                    and os.path.exists(log_file_path)
+                                ):
+                                    try:
+                                        # Benign: literal substrings (incl. user extra_benign) vs regex (ROCProf lines).
+                                        benign_substrings = [
+                                            "Failed to establish connection to the metrics exporter agent",
+                                            "RpcError: Running out of retries to initialize the metrics agent",
+                                            "Metrics will not be exported",
+                                            "FutureWarning",
+                                            "Opened result file:",
+                                            "SQLite3 generation ::",
+                                            "rocpd_op:",
+                                            "rpd_tracer:",
+                                        ]
+                                        benign_substrings.extend(extra_benign)
+                                        benign_regexes = [
+                                            # ROCProf/glog: E/W prefixes are log levels, not app errors
+                                            r"^E[0-9]{8}.*generateRocpd\.cpp",
+                                            r"^W[0-9]{8}.*simple_timer\.cpp",
+                                            r"^W[0-9]{8}.*generateRocpd\.cpp",
+                                            r"^E[0-9]{8}.*tool\.cpp",
+                                            r"\[rocprofv3\]",
+                                        ]
+
+                                        # Scan in Python (no shell; literals vs regex benign rules are explicit).
+                                        with open(
+                                            log_file_path,
+                                            "r",
+                                            encoding="utf-8",
+                                            errors="ignore",
+                                        ) as _lf:
+                                            log_scan_text = _lf.read()
+
+                                        for pattern in error_patterns:
+                                            if log_text_has_error_pattern(
+                                                log_scan_text,
+                                                pattern,
+                                                benign_substrings,
+                                                benign_regexes,
+                                            ):
+                                                has_errors = True
+                                                print(
+                                                    f"Found error pattern '{pattern}' in logs"
+                                                )
+                                                break
+                                    except Exception:
+                                        pass  # Error checking is optional
+                                elif not scan_logs:
+                                    self.rich_console.print(
+                                        "[dim]ℹ️  Log error pattern scan disabled "
+                                        "(log_error_pattern_scan).[/dim]"
                                     )
 
-                                    # Update perf_super.json with single result
-                                    try:
-                                        scripts_path = model_info.get("scripts", "")
-                                        scripts_base_dir = scripts_base_dir_from(scripts_path)
-                                        
-                                        # Use perf_entry.json as input (already created above)
-                                        if run_results.get("status") == "SUCCESS":
-                                            num_entries = update_perf_super_json(
-                                                single_result="perf_entry.json",
-                                                perf_super_json="perf_super.json",
-                                                scripts_base_dir=scripts_base_dir,
-                                            )
-                                        else:
-                                            num_entries = update_perf_super_json(
-                                                exception_result="perf_entry.json",
-                                                perf_super_json="perf_super.json",
-                                                scripts_base_dir=scripts_base_dir,
-                                            )
-                                        
-                                        # Generate CSV and JSON files from perf_super.json
-                                        update_perf_super_csv(
-                                            perf_super_json="perf_super.json",
-                                            perf_super_csv="perf_super.csv",
-                                            num_entries=num_entries
-                                        )
-                                    except Exception as e:
-                                        print(f"⚠️  Warning: Could not update perf_super files: {e}")
+                                # Status logic: Must have performance AND no errors to be considered success
+                                # Exception: Worker nodes in multi-node training (MAD_COLLECT_METRICS=false)
+                                # are not expected to report global performance metrics
+                                performance_value = run_results.get("performance")
+                                has_performance = (
+                                    performance_value
+                                    and performance_value.strip()
+                                    and performance_value.strip() != "N/A"
+                                )
+
+                                # Check if this is a worker node (not collecting metrics)
+                                is_worker_node = os.environ.get("MAD_COLLECT_METRICS", "true").lower() == "false"
+
+                                if has_errors:
+                                    run_results["status"] = "FAILURE"
+                                    self.rich_console.print(
+                                        f"[red]Status: FAILURE (error patterns detected in logs)[/red]"
+                                    )
+                                elif has_performance:
+                                    run_results["status"] = "SUCCESS"
+                                    self.rich_console.print(
+                                        f"[green]Status: SUCCESS (performance metrics found, no errors)[/green]"
+                                    )
+                                elif is_worker_node:
+                                    # Worker nodes don't report global performance metrics - this is expected
+                                    run_results["status"] = "SUCCESS"
+                                    self.rich_console.print(
+                                        f"[green]Status: SUCCESS (worker node, no errors detected)[/green]"
+                                    )
+                                else:
+                                    run_results["status"] = "FAILURE"
+                                    self.rich_console.print(f"[red]Status: FAILURE (no performance metrics)[/red]")
 
                             except Exception as e:
-                                self.rich_console.print(f"[yellow]Warning: Could not update perf.csv: {e}[/yellow]")
-
-                        # Copy profiler/trace output files from run_directory to base directory before cleanup
-                        # This ensures test files like gpu_info_power_profiler_output.csv and library_trace.csv are accessible
-                        try:
-                            _md = model_dir.replace("\\", "/")
-                            model_docker.sh(
-                                f"cp -- {_bash_quote_path(_md)}/*_profiler_output.csv "
-                                f"{_bash_quote_path('.')} 2>/dev/null || true"
-                            )
-                            model_docker.sh(
-                                f"cp -- {_bash_quote_path(_md)}/*_output.csv "
-                                f"{_bash_quote_path('.')} 2>/dev/null || true"
-                            )
-                            model_docker.sh(
-                                f"cp -- {_bash_quote_path(_md)}/*_trace.csv "
-                                f"{_bash_quote_path('.')} 2>/dev/null || true"
-                            )
-                            model_docker.sh(
-                                _cp_model_dir_file_to_cwd_cmd(model_dir, "library_trace.csv")
-                            )
-                        except Exception as e:
-                            # Ignore errors if no profiler/trace output files exist
-                            pass
-
-                        # Copy multiple_results CSV to workspace root before run_directory is removed
-                        # so SLURM single-node copy can find it at $WORKSPACE/{{ multiple_results }}
-                        mult_res = (model_info.get("multiple_results") or "").strip()
-                        if mult_res:
-                            try:
-                                model_docker.sh(
-                                    _cp_model_dir_file_to_cwd_cmd(model_dir, mult_res)
+                                self.rich_console.print(f"[yellow]Warning: Error in status determination: {e}[/yellow]")
+                                # Fallback to simple performance check
+                                # Worker nodes don't need performance metrics
+                                is_worker_node = os.environ.get("MAD_COLLECT_METRICS", "true").lower() == "false"
+                                run_results["status"] = (
+                                    "SUCCESS"
+                                    if run_results.get("performance") or is_worker_node
+                                    else "FAILURE"
                                 )
-                            except Exception:
+
+                            print(
+                                f"{model_info['name']} performance is {run_results.get('performance', 'N/A')} {run_results.get('metric', '')}"
+                            )
+
+                            # =============================================================================
+                            # Multi-Node Performance Collection (Master Node Only)
+                            # =============================================================================
+                            # For distributed training, only master node should collect metrics
+                            # Check skip_perf_collection flag from additional_context
+                            skip_perf = self.additional_context.get("skip_perf_collection", False)
+
+                            if skip_perf:
+                                self.rich_console.print(
+                                    "[cyan]ℹ️  Worker node: Skipping performance metric collection "
+                                    "(master node will collect results)[/cyan]"
+                                )
+                            else:
+                                # Generate performance results and update perf.csv
+                                self.ensure_perf_csv_exists()
+                                try:
+                                    # Create run details dictionary for CSV generation
+                                    run_details_dict = self.create_run_details_dict(
+                                        model_info, build_info, run_results
+                                    )
+
+                                    # Handle multiple results if specified
+                                    multiple_results = model_info.get("multiple_results", None)
+                                    resolved_multiple_results = (
+                                        _resolve_multiple_results_path(multiple_results, model_dir)
+                                        if multiple_results
+                                        else None
+                                    )
+                                    if (
+                                        resolved_multiple_results
+                                        and run_results.get("status") == "SUCCESS"
+                                    ):
+                                        # Generate common info JSON for multiple results
+                                        common_info = run_details_dict.copy()
+                                        # Remove model-specific fields for common info
+                                        for key in ["model", "performance", "metric", "status"]:
+                                            common_info.pop(key, None)
+
+                                        with open("common_info.json", "w") as f:
+                                            json.dump(common_info, f)
+
+                                        # Update perf.csv with multiple results
+                                        update_perf_csv(
+                                            multiple_results=resolved_multiple_results,
+                                            perf_csv=self.perf_csv_path,
+                                            model_name=run_details_dict["model"],
+                                            common_info="common_info.json",
+                                        )
+                                        print(
+                                            f"Updated perf.csv with multiple results for {model_info['name']}"
+                                        )
+
+                                        # Update perf_super.json with multiple results
+                                        try:
+                                            scripts_path = model_info.get("scripts", "")
+                                            scripts_base_dir = scripts_base_dir_from(scripts_path)
+
+                                            # Reuse common_info.json for super files (no need for duplicate)
+                                            num_entries = update_perf_super_json(
+                                                multiple_results=resolved_multiple_results,
+                                                perf_super_json="perf_super.json",
+                                                model_name=run_details_dict["model"],
+                                                common_info="common_info.json",
+                                                scripts_base_dir=scripts_base_dir,
+                                            )
+
+                                            # Generate CSV and JSON files from perf_super.json
+                                            update_perf_super_csv(
+                                                perf_super_json="perf_super.json",
+                                                perf_super_csv="perf_super.csv",
+                                                num_entries=num_entries
+                                            )
+                                        except Exception as e:
+                                            print(f"⚠️  Warning: Could not update perf_super files: {e}")
+                                    else:
+                                        # Generate single result JSON
+                                        with open("perf_entry.json", "w") as f:
+                                            json.dump(run_details_dict, f)
+
+                                        # Update perf.csv with single result
+                                        if run_results.get("status") == "SUCCESS":
+                                            update_perf_csv(
+                                                single_result="perf_entry.json",
+                                                perf_csv=self.perf_csv_path,
+                                            )
+                                        else:
+                                            update_perf_csv(
+                                                exception_result="perf_entry.json",
+                                                perf_csv=self.perf_csv_path,
+                                            )
+                                        print(
+                                            f"Updated perf.csv with result for {model_info['name']}"
+                                        )
+
+                                        # Update perf_super.json with single result
+                                        try:
+                                            scripts_path = model_info.get("scripts", "")
+                                            scripts_base_dir = scripts_base_dir_from(scripts_path)
+
+                                            # Use perf_entry.json as input (already created above)
+                                            if run_results.get("status") == "SUCCESS":
+                                                num_entries = update_perf_super_json(
+                                                    single_result="perf_entry.json",
+                                                    perf_super_json="perf_super.json",
+                                                    scripts_base_dir=scripts_base_dir,
+                                                )
+                                            else:
+                                                num_entries = update_perf_super_json(
+                                                    exception_result="perf_entry.json",
+                                                    perf_super_json="perf_super.json",
+                                                    scripts_base_dir=scripts_base_dir,
+                                                )
+
+                                            # Generate CSV and JSON files from perf_super.json
+                                            update_perf_super_csv(
+                                                perf_super_json="perf_super.json",
+                                                perf_super_csv="perf_super.csv",
+                                                num_entries=num_entries
+                                            )
+                                        except Exception as e:
+                                            print(f"⚠️  Warning: Could not update perf_super files: {e}")
+
+                                except Exception as e:
+                                    self.rich_console.print(f"[yellow]Warning: Could not update perf.csv: {e}[/yellow]")
+
+                            # Copy profiler/trace output files from run_directory to base directory before cleanup
+                            # This ensures test files like gpu_info_power_profiler_output.csv and library_trace.csv are accessible
+                            try:
+                                _md = model_dir.replace("\\", "/")
+                                model_docker.sh(
+                                    f"cp -- {_bash_quote_path(_md)}/*_profiler_output.csv "
+                                    f"{_bash_quote_path('.')} 2>/dev/null || true"
+                                )
+                                model_docker.sh(
+                                    f"cp -- {_bash_quote_path(_md)}/*_output.csv "
+                                    f"{_bash_quote_path('.')} 2>/dev/null || true"
+                                )
+                                model_docker.sh(
+                                    f"cp -- {_bash_quote_path(_md)}/*_trace.csv "
+                                    f"{_bash_quote_path('.')} 2>/dev/null || true"
+                                )
+                                model_docker.sh(
+                                    _cp_model_dir_file_to_cwd_cmd(model_dir, "library_trace.csv")
+                                )
+                            except Exception as e:
+                                # Ignore errors if no profiler/trace output files exist
                                 pass
+
+                            # Copy multiple_results CSV to workspace root before run_directory is removed
+                            # so SLURM single-node copy can find it at $WORKSPACE/{{ multiple_results }}
+                            mult_res = (model_info.get("multiple_results") or "").strip()
+                            if mult_res:
+                                try:
+                                    model_docker.sh(
+                                        _cp_model_dir_file_to_cwd_cmd(model_dir, mult_res)
+                                    )
+                                except Exception:
+                                    pass
 
                         # Cleanup if not keeping alive and not keeping model directory
                         if not keep_alive and not keep_model_dir:

--- a/src/madengine/orchestration/run_orchestrator.py
+++ b/src/madengine/orchestration/run_orchestrator.py
@@ -669,6 +669,20 @@ class RunOrchestrator:
         """Execute on distributed infrastructure."""
         self.rich_console.print(f"[cyan]Deploying to {target}...[/cyan]\n")
 
+        # Warn about local-only flags that have no effect on distributed targets
+        _local_only_flags = {
+            "--keep-alive": getattr(self.args, "keep_alive", False),
+            "--keep-model-dir": getattr(self.args, "keep_model_dir", False),
+            "--skip-model-run": getattr(self.args, "skip_model_run", False),
+        }
+        _active_local_flags = [name for name, val in _local_only_flags.items() if val]
+        if _active_local_flags:
+            self.rich_console.print(
+                f"[yellow]⚠️  The following flags have no effect on distributed "
+                f"({target}) targets and will be ignored: "
+                f"{', '.join(_active_local_flags)}[/yellow]\n"
+            )
+
         # Import from deployment layer
         from madengine.deployment.factory import DeploymentFactory
         from madengine.deployment.base import DeploymentConfig

--- a/src/madengine/orchestration/run_orchestrator.py
+++ b/src/madengine/orchestration/run_orchestrator.py
@@ -141,9 +141,9 @@ class RunOrchestrator:
         1. Run-only: If manifest_file provided
         2. Full workflow: If tags provided (build + run)
 
-        When args.skip_model_run is True (Policy A), the model execution step is
-        skipped only if this invocation ran a build (_did_build_phase). Otherwise
-        the flag is ignored with a warning.
+        When args.skip_model_run is True, the model script inside each container
+        is skipped (container still starts, pre_scripts still run). Use with
+        --keep-alive to leave a live container for manual exec.
 
         Args:
             manifest_file: Path to build_manifest.json
@@ -259,14 +259,6 @@ class RunOrchestrator:
                 target = deployment_config.get("target", "local")
             
             self.rich_console.print(f"[bold cyan]Deployment target: {target}[/bold cyan]\n")
-
-            # Use `is True` so MagicMock-based test doubles do not count as enabled.
-            skip_requested = getattr(self.args, "skip_model_run", False) is True
-            if skip_requested and not self._did_build_phase:
-                self.rich_console.print(
-                    "[yellow]⚠️  --skip-model-run is ignored "
-                    "(not a build+run workflow in this invocation).[/yellow]\n"
-                )
 
             # Step 4: Execute based on target
             try:

--- a/src/madengine/orchestration/run_orchestrator.py
+++ b/src/madengine/orchestration/run_orchestrator.py
@@ -268,26 +268,6 @@ class RunOrchestrator:
                     "(not a build+run workflow in this invocation).[/yellow]\n"
                 )
 
-            if skip_requested and self._did_build_phase:
-                self.rich_console.print(
-                    "[bold cyan]Skipping model run (--skip-model-run) after build.[/bold cyan]\n"
-                )
-                results = {
-                    "successful_runs": [],
-                    "failed_runs": [],
-                    "total_runs": 0,
-                    "skipped_model_run": True,
-                }
-                results["session_start_row"] = session_start_row
-                results["session_row_count"] = (
-                    self.session_tracker.get_session_row_count()
-                )
-                self.rich_console.print(
-                    "\n[dim]🧹 Cleaning up madengine package files...[/dim]"
-                )
-                self._cleanup_model_dir_copies()
-                return results
-
             # Step 4: Execute based on target
             try:
                 if target == "local" or target == "docker":
@@ -685,6 +665,7 @@ class RunOrchestrator:
             keep_alive=getattr(self.args, "keep_alive", False),
             keep_model_dir=getattr(self.args, "keep_model_dir", False),
             phase_suffix=phase_suffix,
+            skip_model_run=getattr(self.args, "skip_model_run", False),
         )
 
         self.rich_console.print(f"\n[green]✓ Local execution complete[/green]")

--- a/tests/unit/test_container_runner.py
+++ b/tests/unit/test_container_runner.py
@@ -349,7 +349,7 @@ class TestRunContainerSkipModelRun:
                           side_effect=lambda cmd, **kw: docker_sh_calls.append(cmd) or "ok"), \
              patch.object(Docker, "__del__", return_value=None), \
              patch("builtins.open", mock_open(read_data="")):
-            runner.run_container(
+            return runner.run_container(
                 model_info=model_info,
                 docker_image="ci-dummy",
                 **kwargs,
@@ -367,12 +367,13 @@ class TestRunContainerSkipModelRun:
         }
 
         docker_sh_calls = []
-        self._run_container_with_mocks(
+        result = self._run_container_with_mocks(
             runner, model_info, docker_sh_calls,
             skip_model_run=True,
             keep_alive=True,
         )
 
+        assert result["status"] == "SKIPPED"
         # The model run command: "cd run_directory && bash run.sh "
         assert not any(
             "run.sh" in c and "cd " in c for c in docker_sh_calls

--- a/tests/unit/test_container_runner.py
+++ b/tests/unit/test_container_runner.py
@@ -5,7 +5,7 @@ import os
 import re
 import subprocess
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -291,3 +291,110 @@ class TestGatherSystemEnvDetailsRocenvMode:
         runner.gather_system_env_details(pep, "my_model")
         args = pep["pre_scripts"][0]["args"]
         assert args == "my_model_env lite UBUNTU"
+
+
+class TestRunContainerSkipModelRun:
+    """Tests for skip_model_run flag in run_container."""
+
+    def _make_runner(self):
+        runner = ContainerRunner.__new__(ContainerRunner)
+        runner.context = MagicMock()
+        runner.context.ctx = {
+            "gpu_vendor": "AMD",
+            "docker_env_vars": {},
+            "guest_os": "UBUNTU",
+        }
+        runner.console = MagicMock()
+        runner.console.sh = MagicMock(return_value="root")
+        runner.rich_console = MagicMock()
+        runner.live_output = False
+        runner.additional_context = {}
+        runner.credentials = {}
+        runner.data = None
+        runner.perf_csv_path = "/tmp/test_perf.csv"
+        return runner
+
+    def _run_container_with_mocks(self, runner, model_info, docker_sh_calls, **kwargs):
+        """Call run_container with all the infrastructure mocked away.
+
+        Patches:
+        - _resolve_docker_image  — skip Docker image existence check
+        - get_gpu_arg / get_cpu_arg / get_env_arg / get_mount_arg — skip option building
+        - gather_system_env_details — skip env-probe scripts injection
+        - finalize_container_rocm_path — skip in-container ROCm probe (AMD path)
+        - Timeout — replace with a no-op context manager
+        - Docker.__init__ / Docker.sh / Docker.__del__ — intercept all container calls
+        - builtins.open — avoid writing real log files
+        """
+        from contextlib import contextmanager
+
+        from madengine.core.docker import Docker
+
+        @contextmanager
+        def noop_timeout(_):
+            yield
+
+        with patch.object(ContainerRunner, "_resolve_docker_image", return_value="ci-dummy"), \
+             patch.object(ContainerRunner, "get_gpu_arg", return_value=""), \
+             patch.object(ContainerRunner, "get_cpu_arg", return_value=""), \
+             patch.object(ContainerRunner, "get_env_arg", return_value=""), \
+             patch.object(ContainerRunner, "get_mount_arg", return_value=""), \
+             patch.object(ContainerRunner, "gather_system_env_details"), \
+             patch.object(ContainerRunner, "ensure_perf_csv_exists"), \
+             patch("madengine.utils.rocm_path_resolver.finalize_container_rocm_path"), \
+             patch("madengine.execution.container_runner._print_run_env_table"), \
+             patch("madengine.execution.container_runner.Timeout", noop_timeout), \
+             patch.object(Docker, "__init__", return_value=None), \
+             patch.object(Docker, "sh",
+                          side_effect=lambda cmd, **kw: docker_sh_calls.append(cmd) or "ok"), \
+             patch.object(Docker, "__del__", return_value=None), \
+             patch("builtins.open", mock_open(read_data="")):
+            runner.run_container(
+                model_info=model_info,
+                docker_image="ci-dummy",
+                **kwargs,
+            )
+
+    def test_skip_model_run_does_not_exec_script(self):
+        """With skip_model_run=True the model script is never executed."""
+        runner = self._make_runner()
+        model_info = {
+            "name": "dummy",
+            "scripts": "scripts/dummy/run.sh",
+            "args": "",
+            "n_gpus": "1",
+            "tags": [],
+        }
+
+        docker_sh_calls = []
+        self._run_container_with_mocks(
+            runner, model_info, docker_sh_calls,
+            skip_model_run=True,
+            keep_alive=True,
+        )
+
+        # The model run command: "cd run_directory && bash run.sh "
+        assert not any(
+            "run.sh" in c and "cd " in c for c in docker_sh_calls
+        ), f"Model script was executed despite skip_model_run=True: {docker_sh_calls}"
+
+    def test_skip_model_run_false_does_exec_script(self):
+        """With skip_model_run=False (default) the model script IS executed."""
+        runner = self._make_runner()
+        model_info = {
+            "name": "dummy",
+            "scripts": "scripts/dummy/run.sh",
+            "args": "",
+            "n_gpus": "1",
+            "tags": [],
+        }
+
+        docker_sh_calls = []
+        self._run_container_with_mocks(
+            runner, model_info, docker_sh_calls,
+            skip_model_run=False,
+        )
+
+        assert any(
+            "run.sh" in c and "cd " in c for c in docker_sh_calls
+        ), f"Model script was not executed: {docker_sh_calls}"

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -200,7 +200,7 @@ class TestSkipModelRunPolicyA:
 
     @patch.object(RunOrchestrator, "_cleanup_model_dir_copies")
     def test_skip_after_build_skips_execute_local(self, mock_cleanup, tmp_path):
-        """Full workflow: skip_model_run + build phase skips _execute_local."""
+        """Full workflow: skip_model_run + build phase still calls _execute_local (skip handled inside container runner)."""
         perf = tmp_path / "perf.csv"
         manifest_path = tmp_path / "build_manifest.json"
         manifest_path.write_text(

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -195,11 +195,11 @@ class TestManifestValidation:
 
 
 @pytest.mark.unit
-class TestSkipModelRunPolicyA:
-    """Policy A: --skip-model-run only skips execution after an internal build."""
+class TestSkipModelRun:
+    """--skip-model-run is forwarded to the container runner; it never short-circuits _execute_local."""
 
     @patch.object(RunOrchestrator, "_cleanup_model_dir_copies")
-    def test_skip_after_build_skips_execute_local(self, mock_cleanup, tmp_path):
+    def test_skip_after_build_calls_execute_local(self, mock_cleanup, tmp_path):
         """Full workflow: skip_model_run + build phase still calls _execute_local (skip handled inside container runner)."""
         perf = tmp_path / "perf.csv"
         manifest_path = tmp_path / "build_manifest.json"
@@ -241,10 +241,10 @@ class TestSkipModelRunPolicyA:
         mock_cleanup.assert_called()
 
     @patch.object(RunOrchestrator, "_cleanup_model_dir_copies")
-    def test_skip_ignored_when_run_only_still_calls_execute_local(
+    def test_skip_run_only_still_calls_execute_local(
         self, mock_cleanup, tmp_path
     ):
-        """Run-only: skip_model_run is ignored; _execute_local runs."""
+        """Run-only (existing manifest): skip_model_run still calls _execute_local (skip handled inside container runner)."""
         perf = tmp_path / "perf.csv"
         manifest_path = tmp_path / "build_manifest.json"
         manifest_path.write_text(

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -226,15 +226,18 @@ class TestSkipModelRunPolicyA:
                 RunOrchestrator, "_load_and_merge_manifest", side_effect=lambda f: f
             ):
                 with patch.object(RunOrchestrator, "_execute_local") as mock_local:
+                    mock_local.return_value = {
+                        "successful_runs": [],
+                        "failed_runs": [],
+                    }
                     with patch.object(
                         RunOrchestrator, "_combine_build_and_run_logs"
-                    ) as mock_combine:
+                    ):
                         orchestrator.execute(
                             manifest_file=None, tags=["dummy"], timeout=60
                         )
 
-        mock_local.assert_not_called()
-        mock_combine.assert_not_called()
+        mock_local.assert_called_once()
         mock_cleanup.assert_called()
 
     @patch.object(RunOrchestrator, "_cleanup_model_dir_copies")
@@ -268,6 +271,45 @@ class TestSkipModelRunPolicyA:
                 "failed_runs": [],
             }
             orchestrator.execute(manifest_file=str(manifest_path), tags=None, timeout=60)
+
+        mock_local.assert_called_once()
+        mock_cleanup.assert_called()
+
+    @patch.object(RunOrchestrator, "_cleanup_model_dir_copies")
+    def test_skip_model_run_calls_execute_local(self, mock_cleanup, tmp_path):
+        """skip_model_run no longer short-circuits before _execute_local."""
+        perf = tmp_path / "perf.csv"
+        manifest_path = tmp_path / "build_manifest.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "deployment_config": {"target": "local"},
+                    "context": {},
+                    "built_images": {},
+                }
+            )
+        )
+
+        mock_args = MagicMock()
+        mock_args.skip_model_run = True
+        mock_args.additional_context = None
+        mock_args.live_output = False
+        mock_args.output = str(perf)
+
+        orchestrator = RunOrchestrator(mock_args)
+
+        with patch.object(RunOrchestrator, "_build_phase", return_value=str(manifest_path)):
+            with patch.object(
+                RunOrchestrator, "_load_and_merge_manifest", side_effect=lambda f: f
+            ):
+                with patch.object(RunOrchestrator, "_execute_local") as mock_local:
+                    mock_local.return_value = {
+                        "successful_runs": [],
+                        "failed_runs": [],
+                    }
+                    orchestrator.execute(
+                        manifest_file=None, tags=["dummy"], timeout=60
+                    )
 
         mock_local.assert_called_once()
         mock_cleanup.assert_called()

--- a/tests/unit/test_orchestration.py
+++ b/tests/unit/test_orchestration.py
@@ -313,3 +313,49 @@ class TestSkipModelRunPolicyA:
 
         mock_local.assert_called_once()
         mock_cleanup.assert_called()
+
+
+@pytest.mark.unit
+class TestRunOrchestrator:
+    """Test RunOrchestrator methods."""
+
+    def test_distributed_warns_on_local_only_flags(self, tmp_path):
+        """_execute_distributed warns when local-only flags are set."""
+        from unittest.mock import MagicMock, patch
+        from madengine.orchestration.run_orchestrator import RunOrchestrator
+
+        mock_args = MagicMock()
+        mock_args.keep_alive = True
+        mock_args.keep_model_dir = False
+        mock_args.skip_model_run = True
+        mock_args.timeout = 60
+        mock_args.additional_context = None
+        mock_args.live_output = False
+
+        orchestrator = RunOrchestrator(mock_args)
+        orchestrator.additional_context = {}
+
+        # Replace rich_console with a mock so we can inspect print calls
+        mock_rich_console = MagicMock()
+        orchestrator.rich_console = mock_rich_console
+
+        fake_result = MagicMock()
+        fake_result.is_success = True
+        fake_result.deployment_id = "test-id"
+        fake_result.logs_path = None
+        fake_result.metrics = {"successful_runs": [], "failed_runs": []}
+
+        with patch("madengine.deployment.factory.DeploymentFactory.create") as mock_create:
+            mock_deploy = MagicMock()
+            mock_deploy.execute.return_value = fake_result
+            mock_create.return_value = mock_deploy
+
+            orchestrator._execute_distributed("slurm", str(tmp_path / "manifest.json"))
+
+        # Verify warning was printed mentioning the active flags
+        printed = " ".join(
+            str(call) for call in mock_rich_console.print.call_args_list
+        )
+        assert "--keep-alive" in printed
+        assert "--skip-model-run" in printed
+        assert "--keep-model-dir" not in printed  # was False, must not appear


### PR DESCRIPTION
## Summary

  - Moves --skip-model-run check from the orchestration layer into ContainerRunner.run_container(), matching the legacy v1 behaviour: the Docker container starts, pre_scripts run, and
  only the model script invocation is skipped. Using --skip-model-run --keep-alive now leaves a live, fully-set-up container for manual exec — which was silently broken before (no
  container was ever started).
  - Sets status = "SKIPPED" (not "FAILURE") for skipped runs, preventing false RUN_FAILURE exit codes and misleading entries in perf.csv.
  - Adds a warning when --keep-alive, --keep-model-dir, or --skip-model-run are passed with a distributed (SLURM/K8s) target, since these flags are local Docker-only and were silently
  ignored.
  - Updates --skip-model-run CLI help text to document the new semantics.

##  Behaviour change

  ```
┌───────────────────────────────┬────────────────────────────────────┬────────────────────────────────────────────────────┐
  │           Scenario            │               Before               │                       After                        │
  ├───────────────────────────────┼────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ --skip-model-run alone        │ exits before container starts      │ container starts, script skipped, status SKIPPED   │
  ├───────────────────────────────┼────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ --skip-model-run --keep-alive │ keep-alive no-op (nothing to keep) │ live container left running, ready for manual exec │
  ├───────────────────────────────┼────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ --skip-model-run on SLURM/K8s │ silently ignored                   │ yellow warning printed, then ignored               │
  └───────────────────────────────┴────────────────────────────────────┴────────────────────────────────────────────────────┘
```

##  Test plan

  - [ ] pytest tests/unit/ -q — 472 tests pass
  - [ ] MODEL_DIR=tests/fixtures/dummy madengine run --tags dummy --additional-context '{"gpu_vendor": "AMD", "guest_os": "UBUNTU"}' --keep-alive --skip-model-run — a ci-dummy_* container
  appears in docker ps after the run
  - [ ] docker exec <container> whoami — confirms container is live and accessible
  - [ ] Verify exit code is 0 (not 1) when --skip-model-run is used