### PR TITLE
chore: consolidate all optional deps into default dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.1] - 2026-06-02
 
+### Changed
+
+- **All dependencies are now included by default**: Kubernetes support (`kubernetes>=28.0.0`) and development tools (`pytest>=7.0`, `black`, `mypy`, `isort`, `pre-commit`, etc.) are bundled into the base `dependencies` list. The `[kubernetes]`, `[dev]`, and `[all]` extras have been removed — a plain `pip install madengine` or `pip install -e .` installs everything. All documentation and in-package install guidance has been updated accordingly.
+
+- **`pytest` lower bound pinned to `>=7.0`**: Aligns the dependency pin with `minversion = "7.0"` already declared in `[tool.pytest.ini_options]`, preventing accidental resolution of older pytest versions that cannot run this project's tests.
+
 ### Fixed
 
 - **`tools/` build context path corrected**: `docker build` now resolves the shared tools directory as `./tools` (project root) instead of `./scripts/common/tools`. The previous path was stale — `scripts/common/tools` is a temporary directory populated at runtime by `madengine run`, so it was absent during standalone `madengine build` invocations, silently omitting the `--build-context tools=…` flag and breaking Dockerfiles that rely on it via `COPY --from=tools`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Setup
 
 ```bash
-# Install in development mode with all dependencies
-pip install -e ".[dev]"
-
-# Optional: install Kubernetes support
-pip install -e ".[all]"
+# Install in development mode (all dependencies, including Kubernetes
+# support and dev tools, are included by default)
+pip install -e .
 
 # Setup pre-commit hooks
 pre-commit install

--- a/README.md
+++ b/README.md
@@ -552,15 +552,12 @@ See [CLI Reference](docs/cli-reference.md) for complete options.
 ## 📦 Installation
 
 ```bash
-# Basic installation
+# Install madengine (all dependencies, including Kubernetes support, are included)
 pip install git+https://github.com/ROCm/madengine.git
-
-# With Kubernetes support
-pip install "madengine[kubernetes] @ git+https://github.com/ROCm/madengine.git"
 
 # Development installation
 git clone https://github.com/ROCm/madengine.git
-cd madengine && pip install -e ".[dev]"
+cd madengine && pip install -e .
 ```
 
 See [Installation Guide](docs/installation.md) for detailed instructions.
@@ -638,7 +635,7 @@ We welcome contributions! See [Contributing Guide](docs/contributing.md) for det
 git clone https://github.com/ROCm/madengine.git
 cd madengine
 python3 -m venv venv && source venv/bin/activate
-pip install -e ".[dev]"
+pip install -e .
 
 # Run all tests
 pytest

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,8 +19,8 @@ cd madengine
 python3 -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install in development mode with all dependencies
-pip install -e ".[dev]"
+# Install in development mode (all dependencies are included)
+pip install -e .
 
 # Setup pre-commit hooks (optional but recommended)
 pre-commit install

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,14 +14,8 @@ Complete installation instructions for madengine.
 ### From GitHub
 
 ```bash
-# Basic installation
+# Install madengine (all dependencies, including Kubernetes support, are included)
 pip install git+https://github.com/ROCm/madengine.git
-
-# With Kubernetes support
-pip install "madengine[kubernetes] @ git+https://github.com/ROCm/madengine.git"
-
-# With all optional dependencies
-pip install "madengine[all] @ git+https://github.com/ROCm/madengine.git"
 ```
 
 ### Development Installation
@@ -35,20 +29,16 @@ cd madengine
 python3 -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 
-# Install in editable mode with dev dependencies
-pip install -e ".[dev]"
+# Install in editable mode (dev dependencies are included)
+pip install -e .
 
 # Setup pre-commit hooks (optional, for contributors)
 pre-commit install
 ```
 
-## Optional Dependencies
+## Dependencies
 
-| Extra | Install Command | Use Case |
-|-------|----------------|----------|
-| `kubernetes` | `pip install madengine[kubernetes]` | Kubernetes deployment support |
-| `dev` | `pip install madengine[dev]` | Development tools (pytest, black, mypy, etc.) |
-| `all` | `pip install madengine[all]` | All optional dependencies |
+All dependencies — including Kubernetes deployment support and development tools (pytest, black, mypy, etc.) — are installed by default. There are no optional extras to select.
 
 **Note**: SLURM deployment requires no additional Python dependencies (uses CLI commands).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,18 @@ dependencies = [
   "click>=8.0.0",
   "jinja2>=3.0.0",
   "pyyaml>=6.0",
+  "kubernetes>=28.0.0",
+  "pytest",
+  "pytest-cov",
+  "pytest-xdist",
+  "pytest-timeout",
+  "pytest-mock",
+  "pytest-asyncio",
+  "black>=21.0.0",
+  "flake8",
+  "mypy>=0.910",
+  "isort",
+  "pre-commit",
 ]
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -40,40 +52,6 @@ madengine = "madengine.cli.app:cli_main"
 Homepage = "https://github.com/ROCm/madengine"
 Issues = "https://github.com/ROCm/madengine/issues"
 
-[project.optional-dependencies]
-dev = [
-  "pytest",
-  "pytest-cov",
-  "pytest-xdist",
-  "pytest-timeout",
-  "pytest-mock",
-  "pytest-asyncio",
-  "black>=21.0.0",
-  "flake8",
-  "mypy>=0.910",
-  "isort",
-  "pre-commit",
-]
-# Optional dependencies for distributed deployments
-# Note: SLURM requires no additional dependencies (uses CLI commands)
-kubernetes = [
-  "kubernetes>=28.0.0",
-]
-# Complete development environment (dev + kubernetes deployment)
-all = [
-  "kubernetes>=28.0.0",
-  "pytest",
-  "pytest-cov",
-  "pytest-xdist",
-  "pytest-timeout",
-  "pytest-mock",
-  "pytest-asyncio",
-  "black>=21.0.0",
-  "flake8",
-  "mypy>=0.910",
-  "isort",
-  "pre-commit",
-]
 
 [tool.hatch.build.targets.wheel]
 # scripts/ is listed in .gitignore (to exclude external MAD project scripts/ dirs during dev).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "jinja2>=3.0.0",
   "pyyaml>=6.0",
   "kubernetes>=28.0.0",
-  "pytest",
+  "pytest>=7.0",
   "pytest-cov",
   "pytest-xdist",
   "pytest-timeout",

--- a/src/madengine/deployment/factory.py
+++ b/src/madengine/deployment/factory.py
@@ -91,8 +91,8 @@ def register_default_deployments():
         import warnings
         warnings.warn(
             "Kubernetes deployment target is unavailable: the 'kubernetes' library is not "
-            "installed. Install it with: pip install madengine[kubernetes] "
-            "(or pip install madengine[all]).",
+            "installed. Reinstall madengine (pip install madengine) or install the "
+            "library directly with: pip install kubernetes.",
             UserWarning,
             stacklevel=2,
         )

--- a/src/madengine/deployment/kubernetes.py
+++ b/src/madengine/deployment/kubernetes.py
@@ -132,8 +132,8 @@ class KubernetesDeployment(
         if not KUBERNETES_AVAILABLE:
             raise ImportError(
                 "Kubernetes Python library not installed.\n"
-                "Install with: pip install madengine[kubernetes]\n"
-                "Or: pip install kubernetes"
+                "Reinstall madengine (pip install madengine) or install the "
+                "library directly with: pip install kubernetes"
             )
 
         if not YAML_AVAILABLE:


### PR DESCRIPTION
## Summary

  - Moves all [project.optional-dependencies] (dev tools, pytest plugins, kubernetes) into the core dependencies list in pyproject.toml
  - Removes the dev, kubernetes, and all extras groups entirely
  - Simplifies installation: pip install madengine now includes everything without requiring .[dev] or .[all]

##  Motivation

  Optional dependency groups added friction — contributors had to know to run pip install -e ".[dev]" or pip install -e ".[all]" to get a working dev environment. Consolidating into
  defaults eliminates that bootstrapping ambiguity.

  Test plan

  - [ ] pip install -e . installs all previously-optional packages (kubernetes, pytest, black, etc.)
  - [ ] madengine CLI still works after install
  - [ ] Existing tests pass: pytest