### PR TITLE
feat(slurm): add reservation support to job configuration

### DIFF
--- a/src/madengine/deployment/slurm.py
+++ b/src/madengine/deployment/slurm.py
@@ -676,6 +676,7 @@ class SlurmDeployment(BaseDeployment):
             "network_interface": self.slurm_config.get("network_interface"),
             "exclusive": self.slurm_config.get("exclusive", True),
             "exclude": self.slurm_config.get("exclude"),
+            "reservation": self.slurm_config.get("reservation"),
             "constraint": self.slurm_config.get("constraint"),
             "nodelist": self._normalize_nodelist(self.slurm_config.get("nodelist")),
             "qos": self.slurm_config.get("qos"),

--- a/src/madengine/deployment/templates/slurm/job.sh.j2
+++ b/src/madengine/deployment/templates/slurm/job.sh.j2
@@ -8,6 +8,9 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --gpus-per-node={{ gpus_per_node }}
 #SBATCH --time={{ time_limit }}
+{% if reservation %}
+#SBATCH --reservation={{ reservation }}
+{% endif %}
 {% if nodelist %}
 #SBATCH --nodelist={{ nodelist }}
 {% endif %}


### PR DESCRIPTION
This pull request adds support for specifying a Slurm reservation in job submissions. The main changes ensure that the `reservation` parameter from the Slurm configuration is passed through the deployment code and correctly rendered in the Slurm job script template.

Support for Slurm reservation:

* Added the `reservation` field to the Slurm job configuration dictionary in `slurm.py`, so it can be accessed and used when generating job scripts.
* Updated the Slurm job script template (`job.sh.j2`) to include the `#SBATCH --reservation` directive if a reservation is specified.- Updated SlurmDeployment to include a new "reservation" field in the job configuration, allowing users to specify job reservations.
- Modified job.sh.j2 template to conditionally include the reservation directive in the SLURM job script if a reservation is provided.

This enhancement improves the flexibility of job submissions in SLURM environments.