### PR TITLE
build_orchestrator: merge model-card slurm/distributed config in the main build path

### DIFF
--- a/src/madengine/orchestration/build_orchestrator.py
+++ b/src/madengine/orchestration/build_orchestrator.py
@@ -1240,7 +1240,7 @@ exit 0
         with open(manifest_output, "r") as f:
             saved_manifest = json.load(f)
 
-        if "deployment_config" not in saved_manifest:
+        if not isinstance(saved_manifest.get("deployment_config"), dict):
             saved_manifest["deployment_config"] = {}
 
         # Merge model's distributed config from the first model.
@@ -1259,7 +1259,7 @@ exit 0
                 )
         model_distributed = models[0].get("distributed", {})
         if model_distributed:
-            if "distributed" not in saved_manifest["deployment_config"]:
+            if not isinstance(saved_manifest["deployment_config"].get("distributed"), dict):
                 saved_manifest["deployment_config"]["distributed"] = {}
 
             # Copy launcher and other critical fields from model config
@@ -1283,7 +1283,7 @@ exit 0
                 )
         model_slurm = models[0].get("slurm", {})
         if model_slurm:
-            if "slurm" not in saved_manifest["deployment_config"]:
+            if not isinstance(saved_manifest["deployment_config"].get("slurm"), dict):
                 saved_manifest["deployment_config"]["slurm"] = {}
 
             # Copy slurm settings from model config (model card fills in

--- a/src/madengine/orchestration/build_orchestrator.py
+++ b/src/madengine/orchestration/build_orchestrator.py
@@ -420,6 +420,10 @@ class BuildOrchestrator:
             # Step 6: Save deployment_config to manifest
             self._save_deployment_config(manifest_output)
 
+            # Step 6b: Merge model's distributed and slurm config into deployment_config
+            # This ensures launcher and slurm settings are in deployment_config even if not in additional-context
+            self._merge_model_config_into_deployment(manifest_output, models)
+
             self.rich_console.print(f"[green]✓ Build complete: {manifest_output}[/green]")
             self.rich_console.print(f"[dim]{'=' * 60}[/dim]\n")
 
@@ -582,70 +586,10 @@ class BuildOrchestrator:
 
             # Save deployment config
             self._save_deployment_config(manifest_output)
-            
+
             # Merge model's distributed and slurm config into deployment_config
             # This ensures launcher and slurm settings are in deployment_config even if not in additional-context
-            if models:
-                with open(manifest_output, "r") as f:
-                    saved_manifest = json.load(f)
-                
-                if "deployment_config" not in saved_manifest:
-                    saved_manifest["deployment_config"] = {}
-                
-                # Merge model's distributed config from the first model.
-                # If multiple models have differing distributed configs, warn — only the first wins here.
-                # Use json.dumps for the hash key so nested dicts (e.g. sglang_disagg / vllm_disagg)
-                # don't trigger TypeError: unhashable type: 'dict' from `tuple(sorted(items()))`.
-                if len(models) > 1:
-                    distinct_distributed = {
-                        json.dumps(m.get("distributed") or {}, sort_keys=True, default=str)
-                        for m in models
-                    }
-                    if len(distinct_distributed) > 1:
-                        self.rich_console.print(
-                            "[yellow]Warning: discovered models have differing distributed configs; "
-                            f"using {models[0].get('name', '<unknown>')}'s config.[/yellow]"
-                        )
-                model_distributed = models[0].get("distributed", {})
-                if model_distributed:
-                    if "distributed" not in saved_manifest["deployment_config"]:
-                        saved_manifest["deployment_config"]["distributed"] = {}
-                    
-                    # Copy launcher and other critical fields from model config
-                    for key in ["launcher", "nnodes", "nproc_per_node", "backend", "port", "sglang_disagg", "vllm_disagg"]:
-                        if key in model_distributed and key not in saved_manifest["deployment_config"]["distributed"]:
-                            saved_manifest["deployment_config"]["distributed"][key] = model_distributed[key]
-                
-                # Merge model's slurm config into deployment_config.slurm from the first model.
-                # This enables run phase to auto-detect SLURM deployment without --additional-context.
-                # Warn when multiple models have differing slurm configs (only the first wins here).
-                # json.dumps key for the same unhashable-nested-dict reason as above.
-                if len(models) > 1:
-                    distinct_slurm = {
-                        json.dumps(m.get("slurm") or {}, sort_keys=True, default=str)
-                        for m in models
-                    }
-                    if len(distinct_slurm) > 1:
-                        self.rich_console.print(
-                            "[yellow]Warning: discovered models have differing slurm configs; "
-                            f"using {models[0].get('name', '<unknown>')}'s config.[/yellow]"
-                        )
-                model_slurm = models[0].get("slurm", {})
-                if model_slurm:
-                    if "slurm" not in saved_manifest["deployment_config"]:
-                        saved_manifest["deployment_config"]["slurm"] = {}
-                    
-                    # Copy slurm settings from model config (model card fills in
-                    # values not explicitly set by --additional-context).
-                    # Use _original_user_slurm_keys (captured before ConfigLoader
-                    # applies defaults) so model card values override defaults
-                    # but user's explicit CLI values still win.
-                    for key in ["partition", "nodes", "gpus_per_node", "time", "exclusive", "reservation", "output_dir", "nodelist"]:
-                        if key in model_slurm and key not in self._original_user_slurm_keys:
-                            saved_manifest["deployment_config"]["slurm"][key] = model_slurm[key]
-                
-                with open(manifest_output, "w") as f:
-                    json.dump(saved_manifest, f, indent=2)
+            self._merge_model_config_into_deployment(manifest_output, models)
 
             self.rich_console.print(f"[green]✓ Generated manifest: {manifest_output}[/green]")
             self.rich_console.print(f"  Pre-built image: {use_image}")
@@ -1283,6 +1227,76 @@ exit 0
 
         except Exception as e:
             self.rich_console.print(f"[yellow]Warning: Could not save build summary: {e}[/yellow]")
+
+    def _merge_model_config_into_deployment(self, manifest_output: str, models: list):
+        """Merge the first discovered model's distributed/slurm config into
+        manifest deployment_config, so the run phase can auto-detect the
+        deployment target (e.g. slurm) from the model card alone, without
+        requiring --additional-context to repeat what's already in models.json.
+        """
+        if not models:
+            return
+
+        with open(manifest_output, "r") as f:
+            saved_manifest = json.load(f)
+
+        if "deployment_config" not in saved_manifest:
+            saved_manifest["deployment_config"] = {}
+
+        # Merge model's distributed config from the first model.
+        # If multiple models have differing distributed configs, warn — only the first wins here.
+        # Use json.dumps for the hash key so nested dicts (e.g. sglang_disagg / vllm_disagg)
+        # don't trigger TypeError: unhashable type: 'dict' from `tuple(sorted(items()))`.
+        if len(models) > 1:
+            distinct_distributed = {
+                json.dumps(m.get("distributed") or {}, sort_keys=True, default=str)
+                for m in models
+            }
+            if len(distinct_distributed) > 1:
+                self.rich_console.print(
+                    "[yellow]Warning: discovered models have differing distributed configs; "
+                    f"using {models[0].get('name', '<unknown>')}'s config.[/yellow]"
+                )
+        model_distributed = models[0].get("distributed", {})
+        if model_distributed:
+            if "distributed" not in saved_manifest["deployment_config"]:
+                saved_manifest["deployment_config"]["distributed"] = {}
+
+            # Copy launcher and other critical fields from model config
+            for key in ["launcher", "nnodes", "nproc_per_node", "backend", "port", "sglang_disagg", "vllm_disagg"]:
+                if key in model_distributed and key not in saved_manifest["deployment_config"]["distributed"]:
+                    saved_manifest["deployment_config"]["distributed"][key] = model_distributed[key]
+
+        # Merge model's slurm config into deployment_config.slurm from the first model.
+        # This enables run phase to auto-detect SLURM deployment without --additional-context.
+        # Warn when multiple models have differing slurm configs (only the first wins here).
+        # json.dumps key for the same unhashable-nested-dict reason as above.
+        if len(models) > 1:
+            distinct_slurm = {
+                json.dumps(m.get("slurm") or {}, sort_keys=True, default=str)
+                for m in models
+            }
+            if len(distinct_slurm) > 1:
+                self.rich_console.print(
+                    "[yellow]Warning: discovered models have differing slurm configs; "
+                    f"using {models[0].get('name', '<unknown>')}'s config.[/yellow]"
+                )
+        model_slurm = models[0].get("slurm", {})
+        if model_slurm:
+            if "slurm" not in saved_manifest["deployment_config"]:
+                saved_manifest["deployment_config"]["slurm"] = {}
+
+            # Copy slurm settings from model config (model card fills in
+            # values not explicitly set by --additional-context).
+            # Use _original_user_slurm_keys (captured before ConfigLoader
+            # applies defaults) so model card values override defaults
+            # but user's explicit CLI values still win.
+            for key in ["partition", "nodes", "gpus_per_node", "time", "exclusive", "reservation", "output_dir", "nodelist"]:
+                if key in model_slurm and key not in self._original_user_slurm_keys:
+                    saved_manifest["deployment_config"]["slurm"][key] = model_slurm[key]
+
+        with open(manifest_output, "w") as f:
+            json.dump(saved_manifest, f, indent=2)
 
     def _save_deployment_config(self, manifest_file: str):
         """Save deployment_config from --additional-context to manifest."""

--- a/src/madengine/orchestration/run_orchestrator.py
+++ b/src/madengine/orchestration/run_orchestrator.py
@@ -517,13 +517,13 @@ class RunOrchestrator:
         # Load manifest first to check if we have Docker images
         with open(manifest_file, "r") as f:
             manifest = json.load(f)
-        
+
         has_docker_images = bool(manifest.get("built_images", {}))
-        
+
         if has_docker_images:
             # Using Docker containers - containers have GPU support built-in
             self.rich_console.print("[dim cyan]Using Docker containers with built-in GPU support[/dim cyan]\n")
-        
+
         # Initialize runtime context (runs full GPU detection on compute nodes)
         self._init_runtime_context()
         
@@ -765,13 +765,13 @@ class RunOrchestrator:
 
         host_os = self.context.ctx.get("host_os", "")
         if "HOST_UBUNTU" in host_os:
-            print(self.console.sh("apt show rocm-libs -a", canFail=True))
+            print(self.console.sh("timeout 10 apt show rocm-libs -a", canFail=True))
         elif "HOST_CENTOS" in host_os:
-            print(self.console.sh("yum info rocm-libs", canFail=True))
+            print(self.console.sh("timeout 10 yum info rocm-libs", canFail=True))
         elif "HOST_SLES" in host_os:
-            print(self.console.sh("zypper info rocm-libs", canFail=True))
+            print(self.console.sh("timeout 10 zypper info rocm-libs", canFail=True))
         elif "HOST_AZURE" in host_os:
-            print(self.console.sh("tdnf info rocm-libs", canFail=True))
+            print(self.console.sh("timeout 10 tdnf info rocm-libs", canFail=True))
         else:
             self.rich_console.print("[yellow]Warning: Unable to detect host OS[/yellow]")
 

--- a/tests/unit/test_slurm_multi.py
+++ b/tests/unit/test_slurm_multi.py
@@ -525,3 +525,85 @@ class TestBuildOnComputeManifestShape:
         for mn in ("model_a", "model_b"):
             assert manifest["built_models"][mn]["built_on_compute"] is True
             assert "DOCKER_IMAGE_NAME" in manifest["built_models"][mn]["env_vars"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Main build path (execute()) must merge model-card slurm/distributed too
+
+class TestMainBuildPathDeploymentConfigMerge:
+    """BuildOrchestrator.execute() (the normal build-from-Dockerfile path used
+    whenever a model isn't built via --use-image or --build-on-compute) must
+    merge the discovered model's `slurm`/`distributed` config into
+    manifest deployment_config, exactly like `_execute_with_prebuilt_image`
+    and `_execute_build_on_compute` already do.
+
+    Regression test for a bug where a model card's non-empty "slurm" config
+    was silently dropped on this path: deployment_config.slurm stayed unset,
+    run_orchestrator._infer_deployment_target() fell back to "local", and on
+    GPU-less SLURM login nodes this caused "GPU detection failed" instead of
+    dispatching via sbatch.
+    """
+
+    def _build_orchestrator_stub(self):
+        from madengine.orchestration.build_orchestrator import BuildOrchestrator
+        orch = BuildOrchestrator.__new__(BuildOrchestrator)
+        orch.args = MagicMock()
+        orch.console = MagicMock()
+        orch.rich_console = MagicMock()
+        orch.context = MagicMock()
+        orch.context.ctx = {"docker_env_vars": {}, "docker_mounts": {}, "docker_build_arg": {}}
+        orch.additional_context = {}
+        orch._original_user_slurm_keys = set()
+        orch.credentials = {}
+        return orch
+
+    def test_execute_merges_model_slurm_and_distributed_with_empty_additional_context(self, tmp_path):
+        """When --additional-context has no "slurm" key at all (the CI case),
+        deployment_config.slurm/distributed must still come from the model card."""
+        fake_model = {
+            "name": "sglang_disagg_deepseek-r1",
+            "dockerfile": "docker/sglang_disagg_inference",
+            "scripts": "scripts/fake/run.sh",
+            "n_gpus": "8",
+            "tags": ["pyt", "sglang"],
+            "args": "",
+            "slurm": {"partition": "amd-rccl", "nodes": 3},
+            "distributed": {
+                "launcher": "sglang-disagg",
+                "sglang_disagg": {"prefill_nodes": 1, "decode_nodes": 1},
+            },
+        }
+
+        # Dummy Dockerfile so builder._get_dockerfiles_for_model()/context
+        # resolution finds a real file instead of raising.
+        df = tmp_path / f"{fake_model['dockerfile']}.ubuntu.amd.Dockerfile"
+        df.parent.mkdir(parents=True, exist_ok=True)
+        df.write_text("FROM scratch\n")
+
+        manifest_path = tmp_path / "build_manifest.json"
+        orch = self._build_orchestrator_stub()
+
+        import os
+        from madengine.execution.docker_builder import DockerBuilder
+        orig_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            with patch("madengine.orchestration.build_orchestrator.DiscoverModels") as mock_dm:
+                mock_dm.return_value.run.return_value = [fake_model]
+                # Skip the real `docker build` subprocess entirely -- the
+                # deployment_config merge only depends on the discovered
+                # models list, not on build success/failure.
+                with patch.object(
+                    DockerBuilder, "build_all_models",
+                    return_value={"successful_builds": [], "failed_builds": []},
+                ):
+                    orch.execute(manifest_output=str(manifest_path))
+        finally:
+            os.chdir(orig_cwd)
+
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["deployment_config"].get("slurm") == {"partition": "amd-rccl", "nodes": 3}
+        assert manifest["deployment_config"].get("distributed") == {
+            "launcher": "sglang-disagg",
+            "sglang_disagg": {"prefill_nodes": 1, "decode_nodes": 1},
+        }

--- a/tests/unit/test_slurm_multi.py
+++ b/tests/unit/test_slurm_multi.py
@@ -548,6 +548,13 @@ class TestMainBuildPathDeploymentConfigMerge:
         from madengine.orchestration.build_orchestrator import BuildOrchestrator
         orch = BuildOrchestrator.__new__(BuildOrchestrator)
         orch.args = MagicMock()
+        # execute() reads these via getattr(self.args, ...) to drive control
+        # flow (multi-arch build loop, live Docker output). A bare MagicMock
+        # attribute is truthy and non-list, which would make `if target_archs:`
+        # true and then iterate a Mock -- set explicit, realistic values so
+        # the test exercises the single-arch build path deterministically.
+        orch.args.target_archs = []
+        orch.args.live_output = False
         orch.console = MagicMock()
         orch.rich_console = MagicMock()
         orch.context = MagicMock()


### PR DESCRIPTION
## Problem

`_execute_with_prebuilt_image()` already merged the first discovered model's `slurm`/`distributed` fields into manifest `deployment_config`, letting the run phase auto-detect `target=slurm` from the model card alone. The normal build-from-Dockerfile path (used whenever images are actually built from source, not `--use-image`) never did this merge -- it only called `_save_deployment_config()`, which populates `deployment_config` purely from `--additional-context`.

A model card with a real `"slurm": {...}` config but no matching `--additional-context` override was silently ignored: `deployment_config.slurm` stayed unset, `_infer_deployment_target()` fell back to `"local"`, and on GPU-less nodes (e.g. a SLURM login node used only to submit jobs) this caused `GPU detection failed: Unable to determine gpu vendor` instead of dispatching via `sbatch`.

## Fix

Extract the merge logic into `_merge_model_config_into_deployment()` and call it from both build paths right after `_save_deployment_config()`.