### PR TITLE
fix(context): resolve amd-smi path in get_gpu_renderD_nodes (ROCM-27727)

### DIFF
--- a/src/madengine/core/context.py
+++ b/src/madengine/core/context.py
@@ -796,8 +796,10 @@ class Context:
             else:
                 # Modern method using amd-smi (ROCm >= 6.4.0)
                 # Get list of GPUs from amd-smi (redirect stderr to filter warnings)
+                # Use resolved path since /opt/rocm*/bin is not guaranteed to be on PATH
                 # Longer timeout (180s) for slow GPU initialization on SLURM compute nodes
-                output = self.console.sh("amd-smi list -e --json 2>/dev/null || amd-smi list -e --json 2>&1", timeout=180)
+                amd_smi_path = os.path.join(self._rocm_path, "bin", "amd-smi")
+                output = self.console.sh(f"{amd_smi_path} list -e --json 2>/dev/null || {amd_smi_path} list -e --json 2>&1", timeout=180)
                 if not output or output.strip() == "":
                     raise ValueError("Failed to retrieve AMD GPU data from amd-smi")
                 


### PR DESCRIPTION
## Summary
- `get_gpu_renderD_nodes()` invoked `amd-smi` as a bare command, relying on it being on `PATH`. On hosts where `/opt/rocm*/bin` is not on `PATH` (e.g. CentOS 9 / MI350 CI runners), the subprocess failed with exit code 127 ("command not found"), causing GPU detection—and the run phase—to abort.
- Every other `amd-smi`/`rocminfo` call site in `context.py` already resolves the binary via `self._rocm_path` (e.g. vendor detection at line ~421, `rocminfo` at line ~552). This fix brings the modern `amd-smi list -e --json` call in line with that pattern by resolving `os.path.join(self._rocm_path, "bin", "amd-smi")` before invoking it.
- Fixes `phantom_disagg_llama70b_mi350` and `phantom_disagg_proxy_moe_mi350` failing with: