### PR TITLE
Add spur (Crusoe) scheduler support for multi-node runs

### DIFF
--- a/src/madengine/deployment/factory.py
+++ b/src/madengine/deployment/factory.py
@@ -81,6 +81,11 @@ def register_default_deployments():
 
     DeploymentFactory.register("slurm", SlurmDeployment)
 
+    # Spur (Crusoe) scheduler: SLURM-compatible CLI with job-array fan-out.
+    from .spur import SpurDeployment
+
+    DeploymentFactory.register("spur", SpurDeployment)
+
     # Register Kubernetes if library is available
     try:
         from .kubernetes import KubernetesDeployment

--- a/src/madengine/deployment/slurm.py
+++ b/src/madengine/deployment/slurm.py
@@ -12,6 +12,7 @@ Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 """
 
 import os
+import re
 import shlex
 import subprocess
 import time
@@ -99,6 +100,38 @@ class SlurmDeployment(BaseDeployment):
                 f"  Allocation has {self.allocation_nodes} nodes available"
             )
 
+    @staticmethod
+    def _expand_nodelist(nodelist: str) -> list:
+        """Expand a SLURM nodelist string into a list of hostnames.
+
+        Stock SLURM emits a compressed form (e.g. "node[01-03,05]") that needs
+        `scontrol show hostnames` to expand. Spur (Crusoe) instead already
+        exposes an expanded comma-separated form (e.g. "nodeA,nodeB") in
+        SLURM_NODELIST and does NOT implement `scontrol show hostname[s]`.
+
+        Strategy: if the string has no range/brace syntax, just split on commas
+        (works on spur). Otherwise try `scontrol show hostnames` and fall back to
+        a naive comma split if that is unavailable.
+        """
+        if not nodelist:
+            return []
+        nodelist = nodelist.strip()
+        if "[" not in nodelist:
+            return [h for h in re.split(r"[,\s]+", nodelist) if h]
+        try:
+            result = subprocess.run(
+                ["scontrol", "show", "hostnames", nodelist],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return [h for h in result.stdout.split("\n") if h.strip()]
+        except Exception:
+            pass
+        # Best-effort fallback (cannot expand ranges without scontrol).
+        return [h for h in re.split(r"[,\s]+", nodelist) if h]
+
     def _get_allocation_node_count(self) -> int:
         """
         Get number of nodes in current SLURM allocation.
@@ -149,21 +182,13 @@ class SlurmDeployment(BaseDeployment):
             except ValueError:
                 pass
         
-        # Last resort: count nodes in SLURM_NODELIST
+        # Last resort: count nodes in SLURM_NODELIST (spur-safe expansion)
         nodelist = os.environ.get("SLURM_NODELIST")
         if nodelist:
-            try:
-                result = subprocess.run(
-                    ["scontrol", "show", "hostname", nodelist],
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                )
-                if result.returncode == 0:
-                    return len(result.stdout.strip().split("\n"))
-            except Exception:
-                pass
-        
+            expanded = self._expand_nodelist(nodelist)
+            if expanded:
+                return len(expanded)
+
         return 0
 
     def _validate_allocation_nodes(self) -> tuple:
@@ -925,13 +950,27 @@ export SGLANG_TP_SIZE={nproc_per_node}
 # Master coordination
 export MASTER_PORT={master_port}
 
-# Build node IP list from SLURM
-SLURM_NODE_IPS=$(scontrol show hostname ${{SLURM_JOB_NODELIST}} | while read node; do
+# Build node IP list from SLURM (scheduler-portable).
+# Stock SLURM: SLURM_JOB_NODELIST is compressed -> expand with `scontrol show
+#   hostnames`. Spur: it is already a comma-separated expanded list and
+#   `scontrol show hostname[s]` is unsupported. Prefer the mad_expand_nodelist
+#   helper defined in the job script header when available.
+if command -v mad_expand_nodelist >/dev/null 2>&1; then
+    _MAD_NODES=$(mad_expand_nodelist "${{SLURM_JOB_NODELIST}}")
+elif [[ "${{SLURM_JOB_NODELIST}}" != *"["* ]]; then
+    _MAD_NODES=$(echo "${{SLURM_JOB_NODELIST}}" | tr ',' '\\n')
+else
+    _MAD_NODES=$(scontrol show hostnames "${{SLURM_JOB_NODELIST}}" 2>/dev/null || echo "${{SLURM_JOB_NODELIST}}" | tr ',' '\\n')
+fi
+SLURM_NODE_IPS=$(echo "$_MAD_NODES" | while read node; do
+    [ -z "$node" ] && continue
     getent hosts "$node" | awk '{{print $1}}'
 done | tr '\\n' ',' | sed 's/,$//')
 
 export SGLANG_NODE_IPS="$SLURM_NODE_IPS"
-export SGLANG_NODE_RANK=${{SLURM_PROCID}}
+# Node rank: stock SLURM sets SLURM_PROCID per srun task. Spur leaves it empty
+# and instead provides NODE_RANK / PMI_RANK / SLURM_NODEID. Fall back in order.
+export SGLANG_NODE_RANK=${{SLURM_PROCID:-${{NODE_RANK:-${{PMI_RANK:-${{SLURM_NODEID:-0}}}}}}}}
 
 echo "=========================================="
 echo "SGLang Disaggregated Cluster Info"
@@ -967,9 +1006,16 @@ echo "=========================================="
 export MAD_MULTI_NODE_RUNNER="deepspeed --num_gpus={nproc_per_node}"'''
         else:
             return f'''# DeepSpeed multi-node setup
-# Generate hostfile dynamically from SLURM
+# Generate hostfile dynamically from SLURM (scheduler-portable nodelist expansion).
+if command -v mad_expand_nodelist >/dev/null 2>&1; then
+    _MAD_DS_NODES=$(mad_expand_nodelist "$SLURM_JOB_NODELIST")
+elif [[ "$SLURM_JOB_NODELIST" != *"["* ]]; then
+    _MAD_DS_NODES=$(echo "$SLURM_JOB_NODELIST" | tr ',' '\\n')
+else
+    _MAD_DS_NODES=$(scontrol show hostnames "$SLURM_JOB_NODELIST" 2>/dev/null || echo "$SLURM_JOB_NODELIST" | tr ',' '\\n')
+fi
 cat > /tmp/deepspeed_hostfile_${{SLURM_JOB_ID}}.txt << EOF
-$(scontrol show hostnames $SLURM_JOB_NODELIST | awk -v slots={nproc_per_node} '{{print $1" slots="slots}}')
+$(echo "$_MAD_DS_NODES" | awk -v slots={nproc_per_node} 'NF{{print $1" slots="slots}}')
 EOF
 export MAD_MULTI_NODE_RUNNER="deepspeed --hostfile=/tmp/deepspeed_hostfile_${{SLURM_JOB_ID}}.txt --master_addr=${{MASTER_ADDR}} --master_port={master_port}"'''
 
@@ -1190,13 +1236,39 @@ export MASTER_PORT={master_port}
         # ==================== END PREFLIGHT ====================
 
         try:
-            # Submit job to SLURM (runs locally on login node)
-            result = subprocess.run(
-                ["sbatch", str(self.script_path)],
-                capture_output=True,
-                text=True,
-                timeout=30,
+            # Submit job to SLURM (runs locally on login node).
+            # Spur compatibility: spur's control plane is Raft-based and can
+            # transiently reject submissions with "not the Raft leader" / "no
+            # leader elected yet" during leader election. Retry a few times.
+            _SUBMIT_RETRIES = 6
+            _SUBMIT_RETRY_DELAY = 5  # seconds
+            _TRANSIENT_MARKERS = (
+                "not the raft leader",
+                "no leader elected",
+                "service is currently unavailable",
+                "leader elected yet",
             )
+            result = None
+            for _attempt in range(1, _SUBMIT_RETRIES + 1):
+                result = subprocess.run(
+                    ["sbatch", str(self.script_path)],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    break
+                _err = (result.stderr or "").lower()
+                _is_transient = any(m in _err for m in _TRANSIENT_MARKERS)
+                if _is_transient and _attempt < _SUBMIT_RETRIES:
+                    self.console.print(
+                        f"[dim yellow]sbatch transient scheduler error "
+                        f"(attempt {_attempt}/{_SUBMIT_RETRIES}), retrying in "
+                        f"{_SUBMIT_RETRY_DELAY}s...[/dim yellow]"
+                    )
+                    time.sleep(_SUBMIT_RETRY_DELAY)
+                    continue
+                break
 
             if result.returncode == 0:
                 # Parse job ID: "Submitted batch job 12345"
@@ -1470,11 +1542,17 @@ export MASTER_PORT={master_port}
         _SACCT_RETRIES = 3
         _SACCT_RETRY_DELAY = 5  # seconds
 
+        # Spur compatibility: spur's sacct shim does NOT support the "-X"
+        # (allocations-only) flag and errors out on it. Omit it. Without "-X",
+        # sacct returns the main job row plus sub-steps (.batch/.extern); we take
+        # the first (main job) row as the authoritative State below.
+        sacct_cmd = ["sacct", "-j", job_id, "-n", "-o", "State"]
+
         try:
             result = None
             for attempt in range(1, _SACCT_RETRIES + 1):
                 result = subprocess.run(
-                    ["sacct", "-j", job_id, "-n", "-X", "-o", "State"],
+                    sacct_cmd,
                     capture_output=True,
                     text=True,
                     timeout=10,
@@ -1490,12 +1568,35 @@ export MASTER_PORT={master_port}
                     time.sleep(_SACCT_RETRY_DELAY)
 
             if result.returncode == 0:
-                status = result.stdout.strip().upper()
+                # First non-empty line is the main job row (State without step
+                # suffix). Sub-step rows (.batch/.extern) follow when "-X" is absent.
+                _lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+                status = (_lines[0].upper() if _lines else "")
                 self.console.print(f"[dim]SLURM job {job_id} final status: {status}[/dim]")
-                
+
                 # Check if live output is enabled
                 live_output = self.config.additional_context.get("live_output", False)
-                
+
+                # The queue check (squeue) can transiently report a job as gone on
+                # eventually-consistent schedulers (e.g. spur's Raft control plane)
+                # while it is still active. If sacct still reports an active state,
+                # treat it as RUNNING instead of FAILED.
+                _ACTIVE_STATES = (
+                    "RUNNING",
+                    "PENDING",
+                    "CONFIGURING",
+                    "COMPLETING",
+                    "REQUEUED",
+                    "RESIZING",
+                    "SUSPENDED",
+                )
+                if any(s in status for s in _ACTIVE_STATES):
+                    return DeploymentResult(
+                        status=DeploymentStatus.RUNNING,
+                        deployment_id=job_id,
+                        message=f"Job {job_id} is {status.lower()}",
+                    )
+
                 if "COMPLETED" in status:
                     # Show final output or summary based on live_output flag
                     if live_output:

--- a/src/madengine/deployment/slurm.py
+++ b/src/madengine/deployment/slurm.py
@@ -56,6 +56,10 @@ class SlurmDeployment(BaseDeployment):
 
     DEPLOYMENT_TYPE = "slurm"
     REQUIRED_TOOLS = ["sbatch", "squeue", "scontrol"]  # Must be available locally
+    # Set by the spur subclass. When True, multi-node fan-out is achieved with a
+    # job array (one single-node task per node) instead of `srun`, because spur's
+    # srun cannot dispatch tasks to other nodes. See SpurDeployment.
+    IS_SPUR = False
 
     def __init__(self, config: DeploymentConfig):
         """
@@ -479,11 +483,23 @@ class SlurmDeployment(BaseDeployment):
             f"#SBATCH --output={self.output_dir}/madengine-{model_info['name']}_%j_%t.out",
             f"#SBATCH --error={self.output_dir}/madengine-{model_info['name']}_%j_%t.err",
             f"#SBATCH --partition={self.partition}",
-            f"#SBATCH --nodes={self.nodes}",
-            f"#SBATCH --ntasks={self.nodes}",
+        ]
+        if self.IS_SPUR:
+            # spur: one single-node task per node via a job array (srun cannot fan out).
+            script_lines.extend([
+                "#SBATCH --nodes=1",
+                "#SBATCH --ntasks=1",
+                f"#SBATCH --array=0-{self.nodes - 1}",
+            ])
+        else:
+            script_lines.extend([
+                f"#SBATCH --nodes={self.nodes}",
+                f"#SBATCH --ntasks={self.nodes}",
+            ])
+        script_lines.extend([
             f"#SBATCH --gpus-per-node={self.gpus_per_node}",
             f"#SBATCH --time={self.time_limit}",
-        ]
+        ])
         # Honour user-configured exclusivity (defaults to True to match the standard SLURM template).
         if self.slurm_config.get("exclusive", True):
             script_lines.append("#SBATCH --exclusive")
@@ -511,6 +527,37 @@ class SlurmDeployment(BaseDeployment):
             script_lines.append(f"export {key}={shlex.quote(str(value))}")
         
         script_lines.append("")
+        if self.IS_SPUR:
+            # spur job-array rank + shared-filesystem rendezvous. Each array task
+            # is one node: SLURM_ARRAY_TASK_ID is the node rank. Pin SLURM_JOB_ID to
+            # the shared SLURM_ARRAY_JOB_ID so the launcher's rendezvous port and
+            # /run_logs/<id> dir match across nodes. rank 0 publishes its transport
+            # IP; peers read it as MASTER_ADDR (see also job.sh.j2 spur branch).
+            rendezvous_dir = getattr(self, "rendezvous_dir", str(self.output_dir.resolve() / "spur_rendezvous"))
+            script_lines.extend([
+                "# --- spur job-array rank + rendezvous ---",
+                'export NODE_RANK="${SLURM_ARRAY_TASK_ID:-0}"',
+                'export SLURM_PROCID="${SLURM_ARRAY_TASK_ID:-0}"',
+                f"export NNODES={self.nodes}",
+                f"export SLURM_NNODES={self.nodes}",
+                f"export WORLD_SIZE={self.nodes}",
+                'export SLURM_JOB_ID="${SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}"',
+                f'export SLURM_SUBMIT_DIR="${{SLURM_SUBMIT_DIR:-{manifest_dir}}}"',
+                f'_MAD_REND_DIR="{rendezvous_dir}/${{SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}}"',
+                'mkdir -p "$_MAD_REND_DIR" 2>/dev/null || true',
+                '_MAD_IFACE="${NCCL_SOCKET_IFNAME:-ens3}"; _MAD_IFACE="${_MAD_IFACE%%,*}"',
+                '_MAD_MY_IP="$(ip -4 -o addr show "$_MAD_IFACE" 2>/dev/null | awk \'{print $4}\' | cut -d/ -f1 | head -n1)"',
+                '[ -z "$_MAD_MY_IP" ] && _MAD_MY_IP="$(hostname -I | awk \'{print $1}\')"',
+                'if [ "${NODE_RANK}" = "0" ]; then',
+                '    echo "$_MAD_MY_IP" > "$_MAD_REND_DIR/master_addr"',
+                '    export MASTER_ADDR="$_MAD_MY_IP"',
+                'else',
+                '    for _i in $(seq 1 180); do [ -s "$_MAD_REND_DIR/master_addr" ] && break; sleep 1; done',
+                '    export MASTER_ADDR="$(cat "$_MAD_REND_DIR/master_addr" 2>/dev/null)"',
+                'fi',
+                'echo "[spur-rendezvous] rank=${NODE_RANK} node=$(hostname) my_ip=$_MAD_MY_IP MASTER_ADDR=${MASTER_ADDR}"',
+                "",
+            ])
         script_lines.extend([
             "echo '=========================================='",
             "echo 'slurm_multi Launcher'",
@@ -528,7 +575,23 @@ class SlurmDeployment(BaseDeployment):
         docker_image = env_vars.get("DOCKER_IMAGE_NAME", "")
         is_registry_image = docker_image and not docker_image.startswith("ci-") and ("/" in docker_image or "." in docker_image)
         
-        if is_registry_image:
+        if is_registry_image and self.IS_SPUR:
+            # spur: each array task is its own node, so pull locally (no srun fan-out).
+            script_lines.extend([
+                "",
+                "# Pull Docker image on this node (one array task per node)",
+                "echo '=========================================='",
+                f"echo \"[$(hostname)] Pulling {docker_image}...\"",
+                "echo '=========================================='",
+                f"docker pull {docker_image}",
+                "PULL_EXIT=$?",
+                "if [ $PULL_EXIT -ne 0 ]; then",
+                f"    echo \"[$(hostname)] Docker pull failed for {docker_image}\"",
+                "    exit $PULL_EXIT",
+                "fi",
+                "echo ''",
+            ])
+        elif is_registry_image:
             # Add parallel docker pull on all nodes
             # This ensures all nodes have the image before running
             script_lines.extend([
@@ -598,6 +661,14 @@ class SlurmDeployment(BaseDeployment):
             f"echo \"exit_code=$SCRIPT_EXIT_CODE\" > {completion_marker_template}",
             f"echo \"timestamp=$(date -Iseconds)\" >> {completion_marker_template}",
             f"echo \"Completion marker written: {completion_marker_template}\"",
+        ])
+        if self.IS_SPUR:
+            # Per-rank marker consumed by SpurDeployment.monitor() (spur `sacct -j`
+            # is unreliable, so completion is detected from these files).
+            script_lines.extend([
+                'echo "$SCRIPT_EXIT_CODE" > "$_MAD_REND_DIR/done_rank${NODE_RANK}"',
+            ])
+        script_lines.extend([
             "",
             "exit $SCRIPT_EXIT_CODE",
         ])

--- a/src/madengine/deployment/slurm.py
+++ b/src/madengine/deployment/slurm.py
@@ -726,6 +726,9 @@ class SlurmDeployment(BaseDeployment):
             "nproc_per_node": nproc_per_node,
             # Profiling tools (processed for multi-node compatibility)
             "tools": tools,
+            # Scheduler flavor: "slurm" (default) or "spur" (job-array fan-out).
+            # SpurDeployment overrides this and adds "rendezvous_dir".
+            "scheduler": "slurm",
         }
 
     def _generate_launcher_command(

--- a/src/madengine/deployment/spur.py
+++ b/src/madengine/deployment/spur.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Spur (Crusoe) deployment backend.
+
+Spur is an "AI-native" scheduler that exposes SLURM-compatible CLI shims
+(sbatch/srun/squeue/sacct/scontrol/...) but differs from stock SLURM in ways
+that break the standard multi-node flow:
+
+  * `srun` cannot fan out tasks across nodes: any `srun [-N -n] [--mpi ...]`
+    invocation runs the command once on the head node, and SLURM_PROCID is
+    empty inside srun. The stock madengine template relies on
+    `srun bash task_script` launching one task per node with a unique
+    SLURM_PROCID, so only rank 0 would ever start.
+  * `scontrol show hostname[s]` is unsupported (SLURM_NODELIST is already an
+    expanded comma list).
+  * The control plane is Raft-based / eventually consistent: sbatch can
+    transiently fail ("not the Raft leader") and squeue/sacct states flap.
+
+Strategy: reuse the SLURM template and orchestration, but drive multi-node
+execution with a job ARRAY of single-node tasks (one array task per node).
+`SLURM_ARRAY_TASK_ID` is the node rank; the tasks self-form the cluster via the
+model launcher's TCP rendezvous (rank 0 publishes its transport IP to a shared
+filesystem, peers read it as MASTER_ADDR). The spur-specific branches live in
+`templates/slurm/job.sh.j2` under `{% if scheduler == 'spur' %}` and are enabled
+purely by the template context produced here.
+
+Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+"""
+
+from typing import Any, Dict
+
+from .base import DeploymentConfig
+from .slurm import SlurmDeployment
+
+
+class SpurDeployment(SlurmDeployment):
+    """SLURM-compatible deployment for the spur scheduler (job-array fan-out)."""
+
+    DEPLOYMENT_TYPE = "spur"
+    # spur ships slurm-compatible shims. scontrol exists but is only partially
+    # implemented; the spur flow does not depend on it, so we don't require it.
+    REQUIRED_TOOLS = ["sbatch", "squeue", "sacct"]
+
+    def __init__(self, config: DeploymentConfig):
+        super().__init__(config)
+        # Rendezvous root MUST be on a shared (NFS) filesystem visible to every
+        # node: rank 0 writes MASTER_ADDR here and peers read it. output_dir is
+        # under the (shared) submission/run directory.
+        self.rendezvous_dir = str(self.output_dir.resolve() / "spur_rendezvous")
+
+    def _prepare_template_context(self, model_info: Dict) -> Dict[str, Any]:
+        context = super()._prepare_template_context(model_info)
+        context["scheduler"] = "spur"
+        context["rendezvous_dir"] = self.rendezvous_dir
+        return context

--- a/src/madengine/deployment/spur.py
+++ b/src/madengine/deployment/spur.py
@@ -43,6 +43,10 @@ class SpurDeployment(SlurmDeployment):
     # spur ships slurm-compatible shims. scontrol exists but is only partially
     # implemented; the spur flow does not depend on it, so we don't require it.
     REQUIRED_TOOLS = ["sbatch", "squeue", "sacct"]
+    # Drives the spur-specific branches in the inherited SLURM code paths
+    # (template rendering and the slurm_multi launcher): job-array fan-out
+    # instead of srun.
+    IS_SPUR = True
 
     def __init__(self, config: DeploymentConfig):
         super().__init__(config)

--- a/src/madengine/deployment/spur.py
+++ b/src/madengine/deployment/spur.py
@@ -75,28 +75,32 @@ class SpurDeployment(SlurmDeployment):
         consistent on spur, so a transient 0 is tolerated by the caller.
         """
         try:
+            # NOTE: spur's squeue ignores custom -o delimiters (e.g. "%j|%T"
+            # renders as "<name> <state>", space-separated), so parse by
+            # whitespace. Job names produced by the template contain no spaces.
             result = subprocess.run(
-                ["squeue", "-u", os.environ.get("USER", ""), "-h", "-o", "%j|%T"],
+                ["squeue", "-u", os.environ.get("USER", ""), "-h", "-o", "%j %T"],
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
             if result.returncode != 0:
                 return -1  # unknown
+            live_states = {
+                "PENDING",
+                "RUNNING",
+                "CONFIGURING",
+                "COMPLETING",
+                "RESIZING",
+                "SUSPENDED",
+            }
             live = 0
             for line in result.stdout.splitlines():
-                line = line.strip()
-                if not line:
+                parts = line.split()
+                if len(parts) < 2:
                     continue
-                name, _, state = line.partition("|")
-                if name == job_name and state.upper() in (
-                    "PENDING",
-                    "RUNNING",
-                    "CONFIGURING",
-                    "COMPLETING",
-                    "RESIZING",
-                    "SUSPENDED",
-                ):
+                name, state = parts[0], parts[-1]
+                if name == job_name and state.upper() in live_states:
                     live += 1
             return live
         except Exception:

--- a/src/madengine/deployment/spur.py
+++ b/src/madengine/deployment/spur.py
@@ -27,9 +27,12 @@ purely by the template context produced here.
 Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 """
 
+import os
+import subprocess
+from pathlib import Path
 from typing import Any, Dict
 
-from .base import DeploymentConfig
+from .base import DeploymentConfig, DeploymentResult, DeploymentStatus
 from .slurm import SlurmDeployment
 
 
@@ -53,3 +56,113 @@ class SpurDeployment(SlurmDeployment):
         context["scheduler"] = "spur"
         context["rendezvous_dir"] = self.rendezvous_dir
         return context
+
+    def _model_job_name(self) -> str:
+        """The #SBATCH --job-name used by the template (madengine-<model name>)."""
+        try:
+            models = self.manifest.get("built_models") or {}
+            first = next(iter(models.values()), {})
+            name = first.get("name") or next(iter(models), "")
+            return f"madengine-{name}"
+        except Exception:
+            return "madengine-"
+
+    def _live_task_count(self, job_name: str) -> int:
+        """Count my not-yet-finished array tasks in the queue (best-effort).
+
+        Used only as a liveness guard so monitor() does not wait forever if a
+        task dies before writing its completion marker. squeue is eventually
+        consistent on spur, so a transient 0 is tolerated by the caller.
+        """
+        try:
+            result = subprocess.run(
+                ["squeue", "-u", os.environ.get("USER", ""), "-h", "-o", "%j|%T"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return -1  # unknown
+            live = 0
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                name, _, state = line.partition("|")
+                if name == job_name and state.upper() in (
+                    "PENDING",
+                    "RUNNING",
+                    "CONFIGURING",
+                    "COMPLETING",
+                    "RESIZING",
+                    "SUSPENDED",
+                ):
+                    live += 1
+            return live
+        except Exception:
+            return -1  # unknown
+
+    # Number of consecutive polls with no completion markers AND no live tasks
+    # before we conclude the array died without reporting. ~poll interval (30s)
+    # times this many => grace window.
+    _SPUR_DEAD_POLLS = 4
+
+    def monitor(self, deployment_id: str) -> DeploymentResult:
+        """Marker-based completion detection for the spur job array.
+
+        Each array task writes ``done_rank<rank>`` (its exit code) into
+        ``<rendezvous_dir>/<array_job_id>/`` on the shared filesystem. We treat
+        those markers as the source of truth because spur's ``sacct -j`` does not
+        filter by job id and ``squeue`` is eventually consistent.
+        """
+        marker_dir = Path(self.rendezvous_dir) / str(deployment_id)
+        n = int(self.nodes)
+
+        codes: Dict[int, int] = {}
+        if marker_dir.is_dir():
+            for rank in range(n):
+                f = marker_dir / f"done_rank{rank}"
+                if f.exists():
+                    try:
+                        codes[rank] = int((f.read_text().strip() or "1"))
+                    except ValueError:
+                        codes[rank] = 1
+
+        if len(codes) >= n:
+            failed = {r: c for r, c in codes.items() if c != 0}
+            if not failed:
+                self._show_log_summary(deployment_id, success=True)
+                return DeploymentResult(
+                    status=DeploymentStatus.SUCCESS,
+                    deployment_id=deployment_id,
+                    message=f"All {n} array tasks completed successfully",
+                )
+            self._show_log_summary(deployment_id, success=False)
+            return DeploymentResult(
+                status=DeploymentStatus.FAILED,
+                deployment_id=deployment_id,
+                message=f"Array task(s) failed (rank:exit) {failed}",
+            )
+
+        # Not all ranks done yet. Guard against a task that died without a marker.
+        live = self._live_task_count(self._model_job_name())
+        if live == 0 and len(codes) < n:
+            self._spur_empty_polls = getattr(self, "_spur_empty_polls", 0) + 1
+            if self._spur_empty_polls >= self._SPUR_DEAD_POLLS:
+                self._show_log_summary(deployment_id, success=False)
+                return DeploymentResult(
+                    status=DeploymentStatus.FAILED,
+                    deployment_id=deployment_id,
+                    message=(
+                        f"Only {len(codes)}/{n} ranks reported completion and no "
+                        f"array tasks remain in the queue"
+                    ),
+                )
+        else:
+            self._spur_empty_polls = 0
+
+        return DeploymentResult(
+            status=DeploymentStatus.RUNNING,
+            deployment_id=deployment_id,
+            message=f"{len(codes)}/{n} ranks done (live tasks: {live})",
+        )

--- a/src/madengine/deployment/spur.py
+++ b/src/madengine/deployment/spur.py
@@ -102,9 +102,12 @@ class SpurDeployment(SlurmDeployment):
         except Exception:
             return -1  # unknown
 
-    # Number of consecutive polls with no completion markers AND no live tasks
-    # before we conclude the array died without reporting. ~poll interval (30s)
-    # times this many => grace window.
+    # Number of consecutive polls, AFTER the tasks were first seen alive, with no
+    # completion markers AND no live tasks before we conclude the array died
+    # without reporting. ~poll interval (30s) times this many => grace window.
+    # The "seen alive first" gate is essential on spur: for the first ~1-2 min
+    # after sbatch, squeue does not yet list the array tasks (registration lag /
+    # eventual consistency), so a fresh, healthy run reports 0 live tasks.
     _SPUR_DEAD_POLLS = 4
 
     def monitor(self, deployment_id: str) -> DeploymentResult:
@@ -144,9 +147,18 @@ class SpurDeployment(SlurmDeployment):
                 message=f"Array task(s) failed (rank:exit) {failed}",
             )
 
-        # Not all ranks done yet. Guard against a task that died without a marker.
+        # Not all ranks done yet. Guard against a task that died without writing a
+        # marker, but only AFTER we have seen the tasks alive at least once: right
+        # after sbatch, spur's squeue does not yet list the array tasks, so a fresh
+        # healthy run legitimately reports 0 live tasks for the first ~1-2 min.
         live = self._live_task_count(self._model_job_name())
-        if live == 0 and len(codes) < n:
+        if live > 0:
+            self._spur_seen_live = True
+            self._spur_empty_polls = 0
+        elif live == 0 and getattr(self, "_spur_seen_live", False) and len(codes) < n:
+            # Tasks were running earlier and now none are queued and not all
+            # ranks reported: a transient empty squeue is possible, so require
+            # several consecutive empty polls before declaring failure.
             self._spur_empty_polls = getattr(self, "_spur_empty_polls", 0) + 1
             if self._spur_empty_polls >= self._SPUR_DEAD_POLLS:
                 self._show_log_summary(deployment_id, success=False)
@@ -159,6 +171,7 @@ class SpurDeployment(SlurmDeployment):
                     ),
                 )
         else:
+            # live == -1 (squeue unavailable/unknown) or still in startup grace.
             self._spur_empty_polls = 0
 
         return DeploymentResult(

--- a/src/madengine/deployment/templates/slurm/job.sh.j2
+++ b/src/madengine/deployment/templates/slurm/job.sh.j2
@@ -46,7 +46,25 @@ module load {{ module }}
 # =============================================================================
 
 # Distributed execution environment (auto-configured from SLURM)
-export MASTER_ADDR=$(scontrol show hostname $SLURM_NODELIST | head -n 1)
+# Scheduler-portable nodelist expansion.
+# Stock SLURM: SLURM_NODELIST is compressed ("node[01-03]") -> needs
+#   `scontrol show hostnames`. Spur (Crusoe): SLURM_NODELIST is already an
+#   expanded comma list ("nodeA,nodeB") and `scontrol show hostname[s]` is
+#   unsupported. Try scontrol only for compressed forms, else split on commas.
+mad_expand_nodelist() {
+    local nl="$1"
+    if [ -z "$nl" ]; then return 0; fi
+    if [[ "$nl" != *"["* ]]; then
+        echo "$nl" | tr ',' '\n'
+        return 0
+    fi
+    if command -v scontrol >/dev/null 2>&1 && scontrol show hostnames "$nl" >/dev/null 2>&1; then
+        scontrol show hostnames "$nl"
+    else
+        echo "$nl" | tr ',' '\n'
+    fi
+}
+export MASTER_ADDR=$(mad_expand_nodelist "$SLURM_NODELIST" | head -n 1)
 export MASTER_PORT={{ master_port | default(29500) }}
 export WORLD_SIZE=$SLURM_NTASKS
 # NOTE: RANK is set per-task inside srun context (not here in main script)

--- a/src/madengine/deployment/templates/slurm/job.sh.j2
+++ b/src/madengine/deployment/templates/slurm/job.sh.j2
@@ -3,9 +3,19 @@
 #SBATCH --output={{ output_dir }}/madengine-{{ model_name }}_%j_%t.out
 #SBATCH --error={{ output_dir }}/madengine-{{ model_name }}_%j_%t.err
 #SBATCH --partition={{ partition }}
+{% if scheduler == 'spur' %}
+# Spur scheduler: srun cannot fan out tasks across nodes, so instead of one
+# multi-node job with `srun bash task` we use a job ARRAY of single-node tasks.
+# Each array task runs on one node; SLURM_ARRAY_TASK_ID is the node rank, and
+# the tasks self-form the cluster via the model launcher's TCP rendezvous.
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --array=0-{{ nodes - 1 }}
+{% else %}
 #SBATCH --nodes={{ nodes }}
 #SBATCH --ntasks={{ nodes }}
 #SBATCH --ntasks-per-node=1
+{% endif %}
 #SBATCH --gpus-per-node={{ gpus_per_node }}
 #SBATCH --time={{ time_limit }}
 {% if reservation %}
@@ -64,6 +74,36 @@ mad_expand_nodelist() {
         echo "$nl" | tr ',' '\n'
     fi
 }
+{% if scheduler == 'spur' %}
+# --- Spur job-array rank + rendezvous ----------------------------------------
+# Each array task is one node. SLURM_ARRAY_TASK_ID is the node rank. We emulate
+# the SLURM_* vars the rest of this script expects, then resolve MASTER_ADDR via
+# a shared-filesystem rendezvous: rank 0 publishes its transport IP; peers wait
+# for and read it. The port is derived from the shared SLURM_ARRAY_JOB_ID so it
+# is identical across all tasks (mirrors the model launcher's rendezvous).
+export SLURM_PROCID="${SLURM_ARRAY_TASK_ID:-0}"
+export SLURM_NNODES={{ nodes }}
+export SLURM_NTASKS={{ nodes }}
+export SLURM_LOCALID="${SLURM_LOCALID:-0}"
+_MAD_REND_DIR="{{ rendezvous_dir }}/${SLURM_ARRAY_JOB_ID:-${SLURM_JOB_ID}}"
+mkdir -p "$_MAD_REND_DIR" 2>/dev/null || true
+_MAD_IFACE="${NCCL_SOCKET_IFNAME:-ens3}"; _MAD_IFACE="${_MAD_IFACE%%,*}"
+_MAD_MY_IP="$(ip -4 -o addr show "$_MAD_IFACE" 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)"
+[ -z "$_MAD_MY_IP" ] && _MAD_MY_IP="$(hostname -I | awk '{print $1}')"
+if [ "${SLURM_PROCID}" = "0" ]; then
+    echo "$_MAD_MY_IP" > "$_MAD_REND_DIR/master_addr"
+    export MASTER_ADDR="$_MAD_MY_IP"
+else
+    for _i in $(seq 1 180); do [ -s "$_MAD_REND_DIR/master_addr" ] && break; sleep 1; done
+    export MASTER_ADDR="$(cat "$_MAD_REND_DIR/master_addr" 2>/dev/null)"
+fi
+echo "[spur-rendezvous] rank=${SLURM_PROCID} node=$(hostname) my_ip=$_MAD_MY_IP MASTER_ADDR=${MASTER_ADDR}"
+export MASTER_PORT={{ master_port | default(29500) }}
+export WORLD_SIZE={{ nodes }}
+export LOCAL_RANK=0
+export NNODES={{ nodes }}
+export GPUS_PER_NODE={{ gpus_per_node }}
+{% else %}
 export MASTER_ADDR=$(mad_expand_nodelist "$SLURM_NODELIST" | head -n 1)
 export MASTER_PORT={{ master_port | default(29500) }}
 export WORLD_SIZE=$SLURM_NTASKS
@@ -72,6 +112,7 @@ export WORLD_SIZE=$SLURM_NTASKS
 export LOCAL_RANK=$SLURM_LOCALID
 export NNODES={{ nodes }}
 export GPUS_PER_NODE={{ gpus_per_node }}
+{% endif %}
 
 # GPU visibility (ROCm/CUDA)
 # IMPORTANT: Ray (vLLM, SGLang) requires HIP_VISIBLE_DEVICES for AMD GPUs
@@ -731,9 +772,18 @@ TASK_SCRIPT_EOF
 
 chmod +x "$TASK_SCRIPT"
 
+{% if scheduler == 'spur' %}
+# Spur: this script IS a single array task pinned to one node. Run the per-node
+# task body directly (spur srun cannot dispatch to other nodes anyway). Node
+# fan-out is achieved by the job array; peers coordinate via the rendezvous above.
+echo "Launching task for node rank ${SLURM_PROCID} (array) on $(hostname)..."
+bash "$TASK_SCRIPT"
+EXIT_CODE=$?
+{% else %}
 echo "Launching tasks on {{ nodes }} nodes..."
 srun bash "$TASK_SCRIPT"
 EXIT_CODE=$?
+{% endif %}
 
 # Cleanup task script
 rm -f "$TASK_SCRIPT"

--- a/src/madengine/deployment/templates/slurm/job.sh.j2
+++ b/src/madengine/deployment/templates/slurm/job.sh.j2
@@ -85,6 +85,15 @@ export SLURM_PROCID="${SLURM_ARRAY_TASK_ID:-0}"
 export SLURM_NNODES={{ nodes }}
 export SLURM_NTASKS={{ nodes }}
 export SLURM_LOCALID="${SLURM_LOCALID:-0}"
+# The model launcher (run.sh) derives its cross-node rendezvous PORT and its
+# shared /run_logs/<id> readiness dir from SLURM_JOB_ID, which therefore MUST be
+# identical on every node. Under a job array each task has its own SLURM_JOB_ID
+# but shares SLURM_ARRAY_JOB_ID, so pin SLURM_JOB_ID to the array id for the
+# container/launcher. (The array task id is preserved via SLURM_PROCID above and
+# in the per-node TASK_SCRIPT filename below.)
+export SLURM_JOB_ID="${SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}"
+# spur may not set SLURM_SUBMIT_DIR; the manifest mounts it for /run_logs.
+export SLURM_SUBMIT_DIR="${SLURM_SUBMIT_DIR:-{{ manifest_file | dirname }}}"
 _MAD_REND_DIR="{{ rendezvous_dir }}/${SLURM_ARRAY_JOB_ID:-${SLURM_JOB_ID}}"
 mkdir -p "$_MAD_REND_DIR" 2>/dev/null || true
 _MAD_IFACE="${NCCL_SOCKET_IFNAME:-ens3}"; _MAD_IFACE="${_MAD_IFACE%%,*}"
@@ -445,7 +454,14 @@ export TORCH_ELASTIC_RDZV_TIMEOUT=3600
 
 # Use submission directory (shared filesystem) for task script
 # /tmp is local to each node and won't be accessible by srun on other nodes
+{% if scheduler == 'spur' %}
+# Under a job array SLURM_JOB_ID is pinned to the shared array id, so include the
+# node rank (array task id) to keep each node's task script path unique on the
+# shared filesystem.
+TASK_SCRIPT="{{ manifest_file | dirname }}/{{ output_dir }}/madengine_task_${SLURM_JOB_ID}_${SLURM_PROCID}.sh"
+{% else %}
 TASK_SCRIPT="{{ manifest_file | dirname }}/{{ output_dir }}/madengine_task_${SLURM_JOB_ID}.sh"
+{% endif %}
 
 cat > "$TASK_SCRIPT" << 'TASK_SCRIPT_EOF'
 #!/bin/bash

--- a/src/madengine/deployment/templates/slurm/job.sh.j2
+++ b/src/madengine/deployment/templates/slurm/job.sh.j2
@@ -170,6 +170,11 @@ export MAD_DEPLOYMENT_TYPE=slurm
 export MAD_SLURM_JOB_ID=$SLURM_JOB_ID
 export MAD_NODE_RANK=$SLURM_NODEID
 export MAD_TOTAL_NODES={{ nodes }}
+# Job id used for cross-node artifact/log collection. On stock SLURM this is the
+# job id. On spur every array task has its own SLURM_JOB_ID but shares
+# SLURM_ARRAY_JOB_ID, which is what collect_results() keys on (== deploy() id).
+# Exported so srun/bash task children inherit the same value.
+export MAD_COLLECT_JOB_ID="${SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}"
 
 # =============================================================================
 # Workspace Setup
@@ -500,7 +505,7 @@ echo ""
 if [ -n "$SLURM_TMPDIR" ] && [ -d "$SLURM_TMPDIR" ] && [ -w "$SLURM_TMPDIR" ]; then
     WORKSPACE=$SLURM_TMPDIR/madengine_node_${SLURM_PROCID}
 else
-    WORKSPACE=/tmp/madengine_job_${SLURM_JOB_ID}_node_${SLURM_PROCID}
+    WORKSPACE=/tmp/madengine_job_${MAD_COLLECT_JOB_ID}_node_${SLURM_PROCID}
 fi
 mkdir -p $WORKSPACE
 WORKSPACE_TYPE="local-multinode"
@@ -535,8 +540,8 @@ echo ""
 # Debug: set node log paths early and trap EXIT so we always see which node failed
 # =============================================================================
 RESULTS_DIR="$SUBMISSION_DIR"
-NODE_LOG_OUT="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${SLURM_PROCID}.out"
-NODE_LOG_ERR="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${SLURM_PROCID}.err"
+NODE_LOG_OUT="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${SLURM_PROCID}.out"
+NODE_LOG_ERR="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${SLURM_PROCID}.err"
 echo "[DEBUG] $(date -Iseconds) Node ${SLURM_PROCID} ($(hostname)): task script started" >> "${NODE_LOG_ERR}"
 trap 'ec=$?; echo "[DEBUG] $(date -Iseconds) Node ${SLURM_PROCID} ($(hostname)): task script exiting with code $ec" >> "${NODE_LOG_ERR}"' EXIT
 
@@ -691,8 +696,8 @@ echo ""
 
 # Create node-specific log files in results directory
 RESULTS_DIR={{ manifest_file | dirname }}
-NODE_LOG_OUT="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${SLURM_PROCID}.out"
-NODE_LOG_ERR="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${SLURM_PROCID}.err"
+NODE_LOG_OUT="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${SLURM_PROCID}.out"
+NODE_LOG_ERR="${RESULTS_DIR}/{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${SLURM_PROCID}.err"
 
 echo "Node ${SLURM_PROCID} logs:"
 echo "  stdout: ${NODE_LOG_OUT}"
@@ -733,7 +738,7 @@ echo "Task completed with exit code: $TASK_EXIT"
 # =============================================================================
 
 SUBMISSION_DIR={{ manifest_file | dirname }}
-JOB_COLLECTION_DIR="${SUBMISSION_DIR}/{{ output_dir }}/{{ model_name }}/${SLURM_JOB_ID}"
+JOB_COLLECTION_DIR="${SUBMISSION_DIR}/{{ output_dir }}/{{ model_name }}/${MAD_COLLECT_JOB_ID}"
 NODE_COLLECTION_DIR="${JOB_COLLECTION_DIR}/node_${SLURM_PROCID}"
 mkdir -p "$NODE_COLLECTION_DIR"
 
@@ -822,13 +827,23 @@ EXIT_CODE=$?
 {% if multiple_results %}
 if [ $EXIT_CODE -eq 0 ]; then
     SUBMISSION_DIR={{ manifest_file | dirname }}
-    JOB_COLLECTION_DIR="${SUBMISSION_DIR}/{{ output_dir }}/{{ model_name }}/${SLURM_JOB_ID}"
+    JOB_COLLECTION_DIR="${SUBMISSION_DIR}/{{ output_dir }}/{{ model_name }}/${MAD_COLLECT_JOB_ID}"
     NODE_COLLECTION_DIR="${JOB_COLLECTION_DIR}/node_0"
     mkdir -p "$NODE_COLLECTION_DIR"
     if [ -f "$WORKSPACE/run_directory/{{ multiple_results }}" ]; then cp "$WORKSPACE/run_directory/{{ multiple_results }}" "$NODE_COLLECTION_DIR/" 2>/dev/null || true; fi
     if [ -f "$WORKSPACE/{{ multiple_results }}" ]; then cp "$WORKSPACE/{{ multiple_results }}" "$NODE_COLLECTION_DIR/" 2>/dev/null || true; fi
 fi
 {% endif %}
+{% endif %}
+
+{% if scheduler == 'spur' %}
+# Spur: publish this array task's exit code so the submitter's monitor() can
+# detect per-rank completion on the shared filesystem. spur `sacct -j` does not
+# filter by job id (returns the whole cluster history), so state cannot be read
+# reliably per job; these markers are the source of truth for completion.
+_MAD_DONE_DIR="{{ rendezvous_dir }}/${SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}"
+mkdir -p "$_MAD_DONE_DIR" 2>/dev/null || true
+echo "$EXIT_CODE" > "$_MAD_DONE_DIR/done_rank${SLURM_PROCID}"
 {% endif %}
 
 # =============================================================================
@@ -854,8 +869,8 @@ if [ $EXIT_CODE -eq 0 ]; then
     echo "  📋 Individual Node Logs ({{ nodes }} nodes):"
     echo "  ─────────────────────────────────────────────"
     for i in $(seq 0 $(({{ nodes }} - 1))); do
-        NODE_OUT="{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${i}.out"
-        NODE_ERR="{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${i}.err"
+        NODE_OUT="{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${i}.out"
+        NODE_ERR="{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${i}.err"
         if [ -f "$NODE_OUT" ]; then
             OUT_SIZE=$(du -h "$NODE_OUT" 2>/dev/null | cut -f1)
             ERR_SIZE=$(du -h "$NODE_ERR" 2>/dev/null | cut -f1)
@@ -877,14 +892,14 @@ else
     echo "  📋 Check Individual Node Logs:"
     echo "  ─────────────────────────────────"
     for i in $(seq 0 $(({{ nodes }} - 1))); do
-        NODE_OUT="{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${i}.out"
-        NODE_ERR="{{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_node_${i}.err"
+        NODE_OUT="{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${i}.out"
+        NODE_ERR="{{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_node_${i}.err"
         if [ -f "$NODE_OUT" ] || [ -f "$NODE_ERR" ]; then
             echo "  Node $i: ${NODE_OUT}"
         fi
     done
     {% else %}
-    echo "  Check logs: {{ output_dir }}/madengine-{{ model_name }}_${SLURM_JOB_ID}_*.out"
+    echo "  Check logs: {{ output_dir }}/madengine-{{ model_name }}_${MAD_COLLECT_JOB_ID}_*.out"
     {% endif %}
     echo "========================================================================"
 fi

--- a/src/madengine/orchestration/run_orchestrator.py
+++ b/src/madengine/orchestration/run_orchestrator.py
@@ -250,13 +250,21 @@ class RunOrchestrator:
             ))
             self.rich_console.print()
 
-            # Infer deployment target from config structure (Convention over Configuration)
-            # No explicit "deploy" field needed - presence of k8s/slurm indicates deployment type
-            target = self._infer_deployment_target(self.additional_context)
-            
-            # Legacy support: check manifest for explicit target
-            if not target or target == "local":
-                target = deployment_config.get("target", "local")
+            # An explicit non-local "target" in deployment_config wins. This is
+            # required for schedulers that reuse another backend's config block:
+            # e.g. the spur backend reuses the "slurm" block, so structural
+            # inference alone would mis-detect it as plain "slurm".
+            explicit_target = deployment_config.get("target")
+            if explicit_target and explicit_target != "local":
+                target = explicit_target
+            else:
+                # Infer deployment target from config structure (Convention over Configuration)
+                # No explicit "deploy" field needed - presence of k8s/slurm indicates deployment type
+                target = self._infer_deployment_target(self.additional_context)
+
+                # Legacy support: check manifest for explicit target
+                if not target or target == "local":
+                    target = deployment_config.get("target", "local")
             
             self.rich_console.print(f"[bold cyan]Deployment target: {target}[/bold cyan]\n")
 


### PR DESCRIPTION
## Summary
Adds support for the spur (Crusoe) scheduler, whose SLURM-compatible CLI
breaks stock multi-node fan-out (`srun` does not dispatch tasks to other
nodes, empty `SLURM_PROCID`; `scontrol show hostnames` unsupported; Raft-based
eventually-consistent squeue/sacct).

- New `SpurDeployment` backend (`target: spur`) that fans out multi-node work
  via a **job array** (one single-node task per node); `SLURM_ARRAY_TASK_ID`
  is the node rank. Nodes self-form the cluster through the launcher's TCP
  rendezvous (rank 0 publishes its transport IP to a shared FS, peers read it
  as `MASTER_ADDR`).
- Marker-based completion detection in `monitor()` (per-rank `done_rank<N>`
  files) because spur `sacct -j` does not filter by job id; squeue used only
  as an eventually-consistent liveness guard.
- `job.sh.j2`: all spur logic gated behind `{% if scheduler == 'spur' %}`;
  `MAD_COLLECT_JOB_ID` unifies log/artifact paths (== `SLURM_JOB_ID` on stock
  SLURM, `SLURM_ARRAY_JOB_ID` on spur).
- Orchestrator: an explicit non-local `target` now wins over structural
  inference (spur reuses the `slurm` config block).
- `slurm_multi` launcher path reworked to fan out via job array on spur.

Stock SLURM behavior is unchanged (spur paths are fully gated; render + import
smoke-checked).

## Test plan
- [ ] Offline: template renders for both `slurm` and `spur` schedulers
- [ ] Stock SLURM multi-node run unaffected (regression)
- [ ] spur amd-spur 4-node run reaches container launch (blocked only by an
      unrelated docker image build issue)